### PR TITLE
Fixes unpack alignment for non-floating point textures

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -192,8 +192,10 @@ void image_impl::render(const void* pWnd, int pX, int pY, int pViewPortWidth, in
     glBindTexture(GL_TEXTURE_2D, mTex);
     // bind PBO to load data into texture
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, mPBO);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
     glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, mWidth, mHeight,
                     mGLformat, mDataType, 0);
+    glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 
     glUniformMatrix4fv(mat_loc, 1, GL_FALSE, matrix);
 


### PR DESCRIPTION
Fixes #1
Fixes #10 
Since `fg::Image` uses normalized integral format for textures, any downstream library using
`fg::Image` should account for the range of the data type image object is created for and re-normalize their data for proper visualization.