### PR TITLE
Added option to reset window close flag

### DIFF
--- a/src/glfw/window.cpp
+++ b/src/glfw/window.cpp
@@ -19,12 +19,14 @@ namespace wtk
 {
 
 Widget::Widget()
-    : mWindow(NULL)
+    : mWindow(NULL), mClose(false)
 {
 }
 
 Widget::Widget(int pWidth, int pHeight, const char* pTitle, const Widget* pWindow, const bool invisible)
 {
+    mClose = false;
+
     if (!glfwInit()) {
         std::cerr << "ERROR: GLFW wasn't able to initalize\n";
         GLFW_THROW_ERROR("glfw initilization failed", fg::FG_ERR_GL_ERROR)
@@ -121,23 +123,32 @@ void Widget::swapBuffers()
 
 void Widget::hide()
 {
+    mClose = true;
     glfwHideWindow(mWindow);
 }
 
 void Widget::show()
 {
+    mClose = false;
     glfwShowWindow(mWindow);
 }
 
 bool Widget::close()
 {
-    return glfwWindowShouldClose(mWindow) != 0;
+    return mClose;
+}
+
+void Widget::resetCloseFlag()
+{
+    if(mClose==true) {
+        show();
+    }
 }
 
 void Widget::keyboardHandler(int pKey, int pScancode, int pAction, int pMods)
 {
     if (pKey == GLFW_KEY_ESCAPE && pAction == GLFW_PRESS) {
-        glfwSetWindowShouldClose(mWindow, GL_TRUE);
+        hide();
     }
 }
 

--- a/src/glfw/window.hpp
+++ b/src/glfw/window.hpp
@@ -32,6 +32,7 @@ namespace wtk
 class Widget {
     private:
         GLFWwindow* mWindow;
+        bool        mClose;
 
         Widget();
 
@@ -61,6 +62,8 @@ class Widget {
         void show();
 
         bool close();
+
+        void resetCloseFlag();
 
         void keyboardHandler(int pKey, int pScancode, int pAction, int pMods);
 

--- a/src/sdl/window.cpp
+++ b/src/sdl/window.cpp
@@ -67,6 +67,7 @@ Widget::Widget(int pWidth, int pHeight, const char* pTitle, const Widget* pWindo
     }
 
     SDL_GL_SetSwapInterval(1);
+    mWindowId = SDL_GetWindowID(mWindow);
 }
 
 Widget::~Widget()
@@ -128,11 +129,13 @@ void Widget::swapBuffers()
 
 void Widget::hide()
 {
+    mClose = true;
     SDL_HideWindow(mWindow);
 }
 
 void Widget::show()
 {
+    mClose = false;
     SDL_ShowWindow(mWindow);
 }
 
@@ -141,21 +144,36 @@ bool Widget::close()
     return mClose;
 }
 
+void Widget::resetCloseFlag()
+{
+    if(mClose==true) {
+        show();
+    }
+}
+
 void Widget::pollEvents()
 {
     SDL_Event evnt;
     SDL_PollEvent(&evnt);
 
-    if (evnt.type == SDL_WINDOWEVENT) {
+    /* handle window events that are triggered
+       when 'this' window was in focus
+     */
+    if (evnt.type == SDL_WINDOWEVENT && evnt.window.windowID == mWindowId) {
         switch(evnt.window.event) {
             case SDL_WINDOWEVENT_CLOSE:
-                mClose = true;
+                hide();
                 break;
         }
-    } else if (evnt.type == SDL_KEYDOWN) {
+    }
+
+    /* handle keyboard press down events that are triggered
+       when 'this' window was in focus
+     */
+    if (evnt.type == SDL_KEYDOWN && evnt.key.windowID == mWindowId) {
         switch(evnt.key.keysym.sym) {
             case SDLK_ESCAPE:
-                mClose = true;
+                hide();
                 break;
         }
     }

--- a/src/sdl/window.hpp
+++ b/src/sdl/window.hpp
@@ -21,6 +21,7 @@ class Widget {
         SDL_Window*     mWindow;
         SDL_GLContext   mContext;
         bool            mClose;
+        uint32_t        mWindowId;
 
         Widget();
 
@@ -54,6 +55,8 @@ class Widget {
         void show();
 
         bool close();
+
+        void resetCloseFlag();
 
         void pollEvents();
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -213,6 +213,7 @@ void window_impl::draw(const std::shared_ptr<AbstractRenderable>& pRenderable)
 {
     CheckGL("Begin drawImage");
     MakeContextCurrent(this);
+    mWindow->resetCloseFlag();
 
     int wind_width, wind_height;
     mWindow->getFrameBufferSize(&wind_width, &wind_height);
@@ -251,6 +252,7 @@ void window_impl::draw(int pColId, int pRowId,
 {
     CheckGL("Begin show(column, row)");
     MakeContextCurrent(this);
+    mWindow->resetCloseFlag();
 
     float pos[2] = {0.0, 0.0};
     int c     = pColId;


### PR DESCRIPTION
This should(mandatory) be called in draw functions. This reset function
basically checks if window was asked to be closed by the user earlier
if so, it resets the flag and raises the window to focus.

This feature basically enables reuse same window multiple times
in the same program and helps avoid creating uncessary additional
windows. However for this feature to work as expected, the
fg::Window::close function should be called in the following loop
constructs only.
* `do-while`
* `for`

`while` cannot work as the condition check is made prior to any draw
call where the window close flag check is happening.