### PR TITLE
Fix freetype2 paths

### DIFF
--- a/src/font.cpp
+++ b/src/font.cpp
@@ -19,8 +19,8 @@
 #include <glm/gtx/transform.hpp>
 
 #include <ft2build.h>
-#include <freetype.h>
-#include <ftglyph.h>
+#include <freetype/freetype.h>
+#include <freetype/ftglyph.h>
 #include FT_FREETYPE_H
 
 #ifndef OS_WIN


### PR DESCRIPTION
A modern freetype2 installation looks like this:

/usr/include/freetype2/ft2build.h
/usr/include/freetype2/freetype/freetype.h
/usr/include/freetype2/freetype/(all other freetype headers)

The FindFreetype.cmake file looks for ft2build.h which it then sets its discovered freetype path to.