### PR TITLE
Add qt5 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ endif(Boost_FOUND AND NOT TARGET Boost::boost)
 
 
 set(WINDOW_TOOLKIT "glfw3" CACHE STRING "Choose Window toolkit")
-set_property(CACHE WINDOW_TOOLKIT PROPERTY STRINGS "glfw3" "sdl2")
+set_property(CACHE WINDOW_TOOLKIT PROPERTY STRINGS "glfw3" "sdl2" "Qt5")
 
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/src/backend/opengl/CMakeLists.txt
+++ b/src/backend/opengl/CMakeLists.txt
@@ -57,6 +57,11 @@ if(${WINDOW_TOOLKIT} STREQUAL "glfw3")
 elseif(${WINDOW_TOOLKIT} STREQUAL "sdl2")
     add_subdirectory(sdl)
     target_compile_definitions(${BackendTarget} PRIVATE USE_SDL)
+elseif(${WINDOW_TOOLKIT} STREQUAL "Qt5")
+    find_package(Qt5Core REQUIRED) #need it for the AUTOMOC to work on the target
+    add_subdirectory(qt5)
+    target_compile_definitions(${BackendTarget} PRIVATE USE_QT5)
+    set_target_properties(${BackendTarget} PROPERTIES AUTOMOC TRUE)
 endif()
 
 if(WITH_FREEIMAGE)
@@ -109,6 +114,8 @@ if(${WINDOW_TOOLKIT} STREQUAL "glfw3")
     source_group("backend\\glfw" REGULAR_EXPRESSION ${Forge_SOURCE_DIR}/src/backend/opengl/glfw/*)
 elseif(${WINDOW_TOOLKIT} STREQUAL "sdl2")
     source_group("backend\\sdl2" REGULAR_EXPRESSION ${Forge_SOURCE_DIR}/src/backend/opengl/sdl/*)
+elseif(${WINDOW_TOOLKIT} STREQUAL "Qt5")
+    source_group("backend\\qt5" REGULAR_EXPRESSION ${Forge_SOURCE_DIR}/src/backend/opengl/qt5/*)
 endif()
 
 #--------------------------------------------------------------------

--- a/src/backend/opengl/qt5/CMakeLists.txt
+++ b/src/backend/opengl/qt5/CMakeLists.txt
@@ -1,0 +1,25 @@
+find_package(Qt5Widgets REQUIRED)
+find_package(Qt5Gui REQUIRED)
+find_package(Qt5OpenGL REQUIRED)
+
+add_library(wtk_interface INTERFACE)
+
+#qt5_wrap_cpp(WTK_MOC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/dockWrapper.hpp)
+#set_source_files_properties(${WTK_MOC_FILES} PROPERTIES GENERATED TRUE) 
+#set_target_properties(${BackendTarget} PROPERTIES AUTOMOC TRUE)
+
+target_include_directories(wtk_interface
+    INTERFACE
+        ${CMAKE_SOURCE_DIR}/src/backend/opengl
+    )
+
+target_sources(wtk_interface
+    INTERFACE
+        ${CMAKE_CURRENT_SOURCE_DIR}/dockWrapper.hpp
+#        ${WTK_MOC_FILES}
+        ${CMAKE_CURRENT_SOURCE_DIR}/dockWrapper.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/window.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/window.cpp
+    )
+
+target_link_libraries(wtk_interface INTERFACE Qt5::Core Qt5::Widgets Qt5::Gui Qt5::OpenGL)

--- a/src/backend/opengl/qt5/dockWrapper.cpp
+++ b/src/backend/opengl/qt5/dockWrapper.cpp
@@ -1,0 +1,57 @@
+#include "dockWrapper.hpp"
+
+#ifndef Q_MOC_RUN 
+#endif
+
+namespace forge
+{
+namespace wtk
+{
+
+DockWrapper::DockWrapper(QWidget *widget, QWidget *parent):
+    QDockWidget(parent)
+{
+    connect(widget, SIGNAL(accepted()), this, SLOT(childAccepted()));
+    connect(widget, SIGNAL(rejected()), this, SLOT(childRejected()));
+    connect(widget, SIGNAL(destroyed(QObject*)), this, SLOT(childDestroyed(QObject*)));
+
+    setMinimumSize(widget->minimumSize());
+    setMaximumSize(widget->maximumSize());
+    setSizePolicy(widget->sizePolicy());
+
+    setAttribute(Qt::WA_DeleteOnClose);
+    setWidget(widget);
+}
+
+DockWrapper::~DockWrapper()
+{
+
+}
+
+QSize DockWrapper::sizeHint() const
+{
+    return widget()->sizeHint();
+}
+
+QSize DockWrapper::minimumSizeHint() const
+{
+    return widget()->minimumSizeHint();
+}
+
+void DockWrapper::childAccepted()
+{
+    emit accepted();
+}
+
+void DockWrapper::childRejected()
+{
+    emit rejected();
+}
+
+void DockWrapper::childDestroyed(QObject *object)
+{
+    close();
+}
+
+}
+}

--- a/src/backend/opengl/qt5/dockWrapper.hpp
+++ b/src/backend/opengl/qt5/dockWrapper.hpp
@@ -1,0 +1,49 @@
+/*******************************************************
+* Copyright (c) 2015-2019, ArrayFire
+* All rights reserved.
+*
+* This file is distributed under 3-clause BSD license.
+* The complete license agreement can be obtained at:
+* http://arrayfire.com/licenses/BSD-3-Clause
+*
+* Original implementation from LimitlessSDK
+* https://github.com/InfiniteInteractive/LimitlessSDK/blob/master/sdk/QtComponents/dockWrapper.h
+********************************************************/
+
+#pragma once
+
+#include <QtWidgets/QDockWidget>
+
+namespace forge
+{
+namespace wtk
+{
+
+class DockWrapper: public QDockWidget
+{
+    Q_OBJECT
+
+public:
+    DockWrapper(QWidget *widget, QWidget *parent=0);
+    ~DockWrapper();
+
+    virtual QSize sizeHint() const;
+    virtual QSize minimumSizeHint() const;
+
+ public slots:
+    void childAccepted();
+    void childRejected();
+    void childDestroyed(QObject *object);
+
+signals:
+    void accepted();
+    void rejected();
+
+protected:
+
+private:
+
+};
+
+}
+}

--- a/src/backend/opengl/qt5/window.cpp
+++ b/src/backend/opengl/qt5/window.cpp
@@ -1,0 +1,373 @@
+/*******************************************************
+* Copyright (c) 2015-2019, ArrayFire
+* All rights reserved.
+*
+* This file is distributed under 3-clause BSD license.
+* The complete license agreement can be obtained at:
+* http://arrayfire.com/licenses/BSD-3-Clause
+********************************************************/
+
+#include <common.hpp>
+#include <qt5/window.hpp>
+#include <gl_native_handles.hpp>
+
+#include <glm/gtc/matrix_transform.hpp>
+#include <iostream>
+
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QMainWindow>
+#include <QtGui/QResizeEvent>
+
+#include <QtOpenGL/QGLWidget>
+
+#include "dockWrapper.hpp"
+
+using namespace gl;
+
+using glm::rotate;
+using glm::translate;
+using glm::scale;
+
+#define SDL_THROW_ERROR(msg, err) \
+    FG_ERROR("Window constructor "#msg,err)
+
+namespace forge
+{
+namespace wtk
+{
+
+QApplication *qtApplication=nullptr;
+QMainWindow *qtMainWindow=nullptr;
+
+class EventFilter:public QObject
+{
+public:
+    EventFilter(Widget *parent):parent(parent){}
+
+    bool eventFilter(QObject *object, QEvent *event)
+    {
+        return parent->eventFilter(object, event);
+    }
+
+private:
+    Widget *parent;
+
+};
+
+void initWindowToolkit()
+{
+}
+
+void destroyWindowToolkit()
+{
+    if(qtApplication!=nullptr)
+    {
+        qtApplication->closeAllWindows();
+        delete qtApplication;
+    }
+}
+
+void setupApplication()
+{
+    int argc=1;
+    char **argv=nullptr;
+
+    qtApplication=new QApplication(argc, argv);
+    qtMainWindow=new QMainWindow();
+}
+
+const glm::mat4 Widget::findTransform(const MatrixHashMap& pMap, const float pX, const float pY)
+{
+    for (auto it: pMap) {
+        const CellIndex& idx = it.first;
+        const glm::mat4& mat  = it.second;
+
+        const int rows = std::get<0>(idx);
+        const int cols = std::get<1>(idx);
+
+        const int cellWidth  = mWidth/cols;
+        const int cellHeight = mHeight/rows;
+
+        const int x = int(pX) / cellWidth;
+        const int y = int(pY) / cellHeight;
+        const int i = x + y * cols;
+        if (i==std::get<2>(idx)) {
+            return mat;
+        }
+    }
+
+    return IDENTITY;
+}
+
+const glm::mat4 Widget::getCellViewMatrix(const float pXPos, const float pYPos)
+{
+    return findTransform(mViewMatrices, pXPos, pYPos);
+}
+
+const glm::mat4 Widget::getCellOrientationMatrix(const float pXPos, const float pYPos)
+{
+    return findTransform(mOrientMatrices, pXPos, pYPos);
+}
+
+void Widget::setTransform(MatrixHashMap& pMap, const float pX, const float pY, const glm::mat4 &pMat)
+{
+    for (auto it: pMap) {
+        const CellIndex& idx = it.first;
+
+        const int rows = std::get<0>(idx);
+        const int cols = std::get<1>(idx);
+
+        const int cellWidth  = mWidth/cols;
+        const int cellHeight = mHeight/rows;
+
+        const int x = int(pX) / cellWidth;
+        const int y = int(pY) / cellHeight;
+        const int i = x + y * cols;
+        if (i==std::get<2>(idx)) {
+            pMap[idx] = pMat;
+        }
+    }
+}
+
+void Widget::setCellViewMatrix(const float pXPos, const float pYPos, const glm::mat4& pMatrix)
+{
+    return setTransform(mViewMatrices, pXPos, pYPos, pMatrix);
+}
+
+void Widget::setCellOrientationMatrix(const float pXPos, const float pYPos, const glm::mat4& pMatrix)
+{
+    return setTransform(mOrientMatrices, pXPos, pYPos, pMatrix);
+}
+
+
+void Widget::resetViewMatrices()
+{
+    for (auto it: mViewMatrices)
+        it.second = IDENTITY;
+}
+
+
+void Widget::resetOrientationMatrices()
+{
+    for (auto it: mOrientMatrices)
+        it.second = IDENTITY;
+}
+
+Widget::Widget()
+    : mWindow(nullptr), mClose(false), mLastXPos(0), mLastYPos(0), mButton(-1),
+    mWidth(512), mHeight(512), mFramePBO(0)
+{
+    initWindow(512, 512, "", nullptr);
+}
+
+Widget::Widget(int pWidth, int pHeight, const char* pTitle, const Widget* pWindow, const bool invisible)
+    : mWindow(nullptr), mClose(false), mLastXPos(0), mLastYPos(0), mButton(-1), mFramePBO(0)
+{
+    initWindow(pWidth, pHeight, pTitle, pWindow);
+}
+
+void Widget::initWindow(int pWidth, int pHeight, const char* pTitle, const Widget* pWindow)
+{
+    //need to wait till glbinding has been init'ed before calling any gl functions
+    //this will have been doen once resizePixelBuffers has been called
+    mWindowCreated=false;
+
+    if(qtApplication==nullptr)
+    {
+        setupApplication();
+        mDockWidget=false;
+    }
+    else//main widow allready exist, make remaining windows docakable
+        mDockWidget=true;
+
+    if(pWindow!=nullptr)
+    {
+        QGLWidget *sharedWidget=dynamic_cast<QGLWidget *>(pWindow->getNativeHandle());
+
+        if(sharedWidget!=nullptr)
+            mWindow=new QGLWidget(nullptr, sharedWidget);
+    }
+
+    if(mWindow==nullptr)
+        mWindow=new QGLWidget();
+
+    mEventFilter=std::unique_ptr<EventFilter>(new EventFilter(this));
+    mWindow->installEventFilter(mEventFilter.get());
+
+    if(mDockWidget)
+    {
+        DockWrapper *wrapper=new DockWrapper(mWindow);
+
+        qtMainWindow->addDockWidget(Qt::RightDockWidgetArea, wrapper);
+        wrapper->setFloating(true);
+    }
+    else
+        qtMainWindow->setCentralWidget(mWindow);
+
+    if(mDockWidget)
+        mWindow->resize(QSize(pWidth, pHeight));
+    else
+        qtMainWindow->resize(QSize(pWidth, pHeight));
+    mWindow->show();
+
+    mWidth=pWidth;
+    mHeight=pHeight;
+
+    qtMainWindow->show();
+
+    qtApplication->processEvents();
+}
+
+Widget::~Widget()
+{
+    mWindow->removeEventFilter(mEventFilter.get());
+
+    if(!mDockWidget)
+        qtMainWindow->close();
+}
+
+QWidget *Widget::getNativeHandle() const
+{
+    return mWindow;
+}
+
+void Widget::makeContextCurrent() const
+{
+    mWindow->makeCurrent();
+}
+
+long long Widget::getGLContextHandle()
+{
+    return opengl::getCurrentContextHandle();
+}
+
+long long Widget::getDisplayHandle()
+{
+    return opengl::getCurrentDisplayHandle();
+}
+
+void Widget::setTitle(const char* pTitle)
+{
+    if(mDockWidget)
+        mWindow->setWindowTitle(QString(pTitle));
+    else
+        qtMainWindow->setWindowTitle(QString(pTitle));
+//    SDL_SetWindowTitle(mWindow, (pTitle!=nullptr ? pTitle : "Forge-Demo"));
+}
+
+void Widget::setPos(int pX, int pY)
+{
+    if(mDockWidget)
+        mWindow->move(pX, pY);
+    else
+        qtMainWindow->move(pX, pY);
+}
+
+void Widget::setSize(unsigned pW, unsigned pH)
+{
+    if(mDockWidget)
+        mWindow->resize(pW, pH);
+    else
+        qtMainWindow->resize(pW, pH);
+
+    mWidth=pW;
+    mHeight=pH;
+}
+
+void Widget::swapBuffers()
+{
+    mWindow->swapBuffers();
+
+    glReadBuffer(GL_FRONT);
+    glBindBuffer((gl::GLenum)GL_PIXEL_PACK_BUFFER, mFramePBO);
+    glReadPixels(0, 0, mWidth, mHeight, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+    glBindBuffer((gl::GLenum)GL_PIXEL_PACK_BUFFER, 0);
+}
+
+void Widget::hide()
+{
+    if(mDockWidget)
+        mWindow->hide();
+    else
+        qtMainWindow->hide();
+}
+
+void Widget::show()
+{
+    if(mDockWidget)
+        mWindow->show();
+    else
+        qtMainWindow->show();
+}
+
+bool Widget::close()
+{
+    return !mWindow->isVisible();
+}
+
+void Widget::resetCloseFlag()
+{
+}
+
+void Widget::pollEvents()
+{
+    if(!mDockWidget)
+        qtApplication->processEvents();
+}
+
+bool Widget::eventFilter(QObject *object, QEvent *event)
+{
+    if(object!=mWindow)
+        return false;
+
+    switch(event->type())
+    {
+    case QEvent::Resize:
+        QResizeEvent *resizeEvent=dynamic_cast<QResizeEvent *>(event);
+
+        if(resizeEvent!=nullptr)
+        {
+            mWidth=resizeEvent->size().width();
+            mHeight=resizeEvent->size().height();
+            if(mWindowCreated)
+                resizePixelBuffers();
+        }
+        break;
+    }
+    return false;
+}
+
+void Widget::resizePixelBuffers()
+{
+    mWindowCreated=true;
+
+    if (mFramePBO!=0)
+        glDeleteBuffers(1, &mFramePBO);
+
+    uint w = mWidth;
+    uint h = mHeight;
+
+    glGenBuffers(1, &mFramePBO);
+    glBindBuffer((gl::GLenum)GL_PIXEL_PACK_BUFFER, mFramePBO);
+    glBufferData((gl::GLenum)GL_PIXEL_PACK_BUFFER, w*h*4*sizeof(uchar), 0, (gl::GLenum)GL_DYNAMIC_READ);
+    glBindBuffer((gl::GLenum)GL_PIXEL_PACK_BUFFER, 0);
+}
+
+const glm::mat4 Widget::getViewMatrix(const CellIndex& pIndex)
+{
+    if (mViewMatrices.find(pIndex)==mViewMatrices.end()) {
+        mViewMatrices.emplace(pIndex, IDENTITY);
+    }
+    return mViewMatrices[pIndex];
+}
+
+const glm::mat4 Widget::getOrientationMatrix(const CellIndex& pIndex)
+{
+    if (mOrientMatrices.find(pIndex)==mOrientMatrices.end()) {
+        mOrientMatrices.emplace(pIndex, IDENTITY);
+    }
+    return mOrientMatrices[pIndex];
+}
+
+}
+}

--- a/src/backend/opengl/qt5/window.hpp
+++ b/src/backend/opengl/qt5/window.hpp
@@ -1,0 +1,117 @@
+/*******************************************************
+* Copyright (c) 2015-2019, ArrayFire
+* All rights reserved.
+*
+* This file is distributed under 3-clause BSD license.
+* The complete license agreement can be obtained at:
+* http://arrayfire.com/licenses/BSD-3-Clause
+********************************************************/
+
+#pragma once
+
+#include <common.hpp>
+#include <QWidget>
+#include <glm/glm.hpp>
+
+class QGLWidget;
+
+namespace forge
+{
+namespace wtk
+{
+
+void initWindowToolkit();
+void destroyWindowToolkit();
+
+class EventFilter;
+
+class Widget {
+    private:
+        QGLWidget *mWindow;
+        std::unique_ptr<EventFilter> mEventFilter;
+        bool          mClose;
+        uint32_t      mWindowId;
+        float         mLastXPos;
+        float         mLastYPos;
+        int           mButton;
+//        SDL_Keycode   mMod;
+        glm::vec3     mLastPos;
+        bool mWindowCreated;
+
+
+        MatrixHashMap mViewMatrices;
+        MatrixHashMap mOrientMatrices;
+
+        Widget();
+        void initWindow(int pWidth, int pHeight, const char* pTitle, const Widget* pWindow=nullptr);
+
+        const glm::mat4 findTransform(const MatrixHashMap& pMap, const float pX, const float pY);
+
+        const glm::mat4 getCellViewMatrix(const float pXPos, const float pYPos);
+
+        const glm::mat4 getCellOrientationMatrix(const float pXPos, const float pYPos);
+
+        void setTransform(MatrixHashMap& pMap, const float pX, const float pY, const glm::mat4 &pMat);
+
+        void setCellViewMatrix(const float pXPos, const float pYPos, const glm::mat4& pMatrix);
+
+        void setCellOrientationMatrix(const float pXPos, const float pYPos, const glm::mat4& pMatrix);
+
+    public:
+        /* public variables */
+        int mWidth;     // Framebuffer width
+        int mHeight;    // Framebuffer height
+        bool mDockWidget;
+
+        uint  mFramePBO;
+
+        /* Constructors and methods */
+        Widget(int pWidth, int pHeight, const char* pTitle, const Widget* pWindow, const bool invisible);
+
+        ~Widget();
+
+        QWidget* getNativeHandle() const;
+
+        void makeContextCurrent() const;
+
+        long long getGLContextHandle();
+
+        long long getDisplayHandle();
+
+        bool getClose() const;
+
+        void setTitle(const char* pTitle);
+
+        void setPos(int pX, int pY);
+
+        void setSize(unsigned pW, unsigned pH);
+
+        void setClose(bool pClose);
+
+        void swapBuffers();
+
+        void hide();
+
+        void show();
+
+        bool close();
+
+        void resetCloseFlag();
+
+        void pollEvents();
+
+        void resizePixelBuffers();
+
+        const glm::mat4 getViewMatrix(const CellIndex& pIndex);
+
+        const glm::mat4 getOrientationMatrix(const CellIndex& pIndex);
+
+        void resetViewMatrices();
+
+        void resetOrientationMatrices();
+
+        bool eventFilter(QObject *object, QEvent *event);
+};
+
+}
+}

--- a/src/backend/opengl/window_impl.hpp
+++ b/src/backend/opengl/window_impl.hpp
@@ -15,6 +15,8 @@
 #include <glfw/window.hpp>
 #elif defined(USE_SDL)
 #include <sdl/window.hpp>
+#elif defined(USE_QT5)
+#include <qt5/window.hpp>
 #endif
 
 #include <colormap_impl.hpp>


### PR DESCRIPTION
Added qt5 support and a CPU example that opens 2 windows. The Qt5 support opens the first window as a QMainWindow, all the remaining windows are opened as QDockWidgets in floating mode. This allows them to be docked if the user wished.

![image](https://cloud.githubusercontent.com/assets/2903823/25585428/1f20a0e4-2e60-11e7-9c40-74d52c2201b2.png)

![image](https://cloud.githubusercontent.com/assets/2903823/25585445/315cc88c-2e60-11e7-8b8d-ba27f439e299.png)
