### PR TITLE
Add qt5 widget ChartWidget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ INCLUDE(Version)
 OPTION(BUILD_DOCUMENTATION "Build Documentation" OFF)
 OPTION(BUILD_EXAMPLES "Build Examples" ON)
 OPTION(USE_FREEIMAGE "Use freeimage to allow saving of charts" ON)
+OPTION(USE_QT5_WIDGET "Creates widget for use with Qt5" OFF)
+
+SET(USE_WINDOW_TOOLKIT "glfw3" CACHE STRING "Choose Window toolkit")
+SET_PROPERTY(CACHE USE_WINDOW_TOOLKIT PROPERTY STRINGS "none" "glfw3" "sdl2")
 
 # Set a default build type if none was specified
 IF(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -76,6 +80,22 @@ IF(APPLE)
     SET(X11_LIBS ${X11_LIBRARIES})
 ENDIF(APPLE)
 
+IF(USE_QT5_WIDGET)
+    find_package(Qt5Core REQUIRED)
+    find_package(Qt5Widgets REQUIRED)
+    find_package(Qt5Gui REQUIRED)
+    find_package(Qt5OpenGL REQUIRED)
+
+    IF(Qt5Core_FOUND)
+        SET(CMAKE_AUTOMOC ON)
+        SET(WTK_INCLUDE_DIRS ${Qt5Core_INCLUDE_DIRS} ${Qt5Widgets_INCLUDE_DIRS} ${Qt5Gui_INCLUDE_DIRS} ${Qt5OpenGL_INCLUDE_DIRS})
+        SET(WTK_LIBRARIES Qt5::Core Qt5::Widgets Qt5::Gui Qt5::OpenGL)
+        ADD_DEFINITIONS(-DUSE_QT5)
+    ELSE(Qt5Core_FOUND)
+        MESSAGE(FATAL_ERROR "Qt5 not found")
+    ENDIF(Qt5Core_FOUND)
+ENDIF()
+
 ADD_SUBDIRECTORY(src/backend)
 
 IF(BUILD_EXAMPLES)
@@ -90,6 +110,16 @@ ENDIF(BUILD_DOCUMENTATION)
 #--------------------------------------------------------------------
 # Create generated files
 #--------------------------------------------------------------------
+
+set(FG_WINDOW_TOOLKIT OFF)
+IF(${USE_WINDOW_TOOLKIT} STREQUAL "glfw3")
+    set(FG_WINDOW_TOOLKIT ON)
+ELSEIF(${USE_WINDOW_TOOLKIT} STREQUAL "sdl2")
+    set(FG_WINDOW_TOOLKIT ON)
+ENDIF()
+
+configure_file(config.h.in "${CMAKE_CURRENT_SOURCE_DIR}/include/fg/config.h" @ONLY)
+
 INCLUDE(CMakePackageConfigHelpers)
 
 configure_package_config_file("${PROJECT_SOURCE_DIR}/CMakeModules/ForgeConfig.cmake.in"

--- a/CMakeModules/build_glbinding.cmake
+++ b/CMakeModules/build_glbinding.cmake
@@ -2,12 +2,8 @@ INCLUDE(ExternalProject)
 
 SET(prefix ${PROJECT_BINARY_DIR}/third_party/glb)
 
-SET(LIB_POSTFIX "")
-IF (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-    SET(LIB_POSTFIX "d")
-ENDIF()
-
-SET(glbinding_location ${prefix}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}glbinding${LIB_POSTFIX}${CMAKE_STATIC_LIBRARY_SUFFIX})
+SET(glbinding_location ${prefix}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}glbinding${CMAKE_STATIC_LIBRARY_SUFFIX})
+SET(glbinding_location_debug ${prefix}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}glbindingd${CMAKE_STATIC_LIBRARY_SUFFIX})
 
 IF(CMAKE_VERSION VERSION_LESS 3.2)
     IF(CMAKE_GENERATOR MATCHES "Ninja")
@@ -48,7 +44,8 @@ ADD_LIBRARY(glbinding IMPORTED STATIC)
 
 ExternalProject_Get_Property(glb-ext install_dir)
 
-SET_TARGET_PROPERTIES(glbinding PROPERTIES IMPORTED_LOCATION ${glbinding_location})
+SET_TARGET_PROPERTIES(glbinding PROPERTIES IMPORTED_LOCATION_RELEASE ${glbinding_location})
+SET_TARGET_PROPERTIES(glbinding PROPERTIES IMPORTED_LOCATION_DEBUG ${glbinding_location_debug})
 
 ADD_DEPENDENCIES(glbinding glb-ext)
 

--- a/config.h.in
+++ b/config.h.in
@@ -1,0 +1,2 @@
+#cmakedefine FG_WINDOW_TOOLKIT
+#cmakedefine USE_QT5_WIDGET

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -84,83 +84,120 @@ IF(UNIX)
     SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations -Wno-unused-function")
 ENDIF()
 
-FILE(GLOB CPU_EXAMPLE_SRC_FILES "cpu/*.cpp")
-LIST(SORT CPU_EXAMPLE_SRC_FILES)
-FOREACH(FILE ${CPU_EXAMPLE_SRC_FILES})
-    GET_FILENAME_COMPONENT(EXAMPLE ${FILE} NAME_WE)
-    GET_FILENAME_COMPONENT(FULL_DIR_NAME ${FILE} PATH)
-    GET_FILENAME_COMPONENT(DIR_NAME ${FULL_DIR_NAME} NAME)
+IF(FG_WINDOW_TOOLKIT)
+    FILE(GLOB CPU_EXAMPLE_SRC_FILES "cpu/*.cpp")
+    LIST(SORT CPU_EXAMPLE_SRC_FILES)
+    FOREACH(FILE ${CPU_EXAMPLE_SRC_FILES})
+        GET_FILENAME_COMPONENT(EXAMPLE ${FILE} NAME_WE)
+        GET_FILENAME_COMPONENT(FULL_DIR_NAME ${FILE} PATH)
+        GET_FILENAME_COMPONENT(DIR_NAME ${FULL_DIR_NAME} NAME)
 
-    IF(TARGET forge)
-        BUILD_EXAMPLE(${EXAMPLE} ${FILE} ${DIR_NAME} forge "")
-    ELSE(TARGET forge)
-        BUILD_EXAMPLE(${EXAMPLE} ${FILE} ${DIR_NAME} ${FORGE_LIBRARIES} "${X11_LIBS};${OPENGL_gl_LIBRARY}")
+        IF(TARGET forge)
+            BUILD_EXAMPLE(${EXAMPLE} ${FILE} ${DIR_NAME} forge "")
+        ELSE(TARGET forge)
+            BUILD_EXAMPLE(${EXAMPLE} ${FILE} ${DIR_NAME} ${FORGE_LIBRARIES} "${X11_LIBS};${OPENGL_gl_LIBRARY}")
+        ENDIF()
+    ENDFOREACH()
+
+    IF (BUILD_EXAMPLES_CUDA)
+        FIND_PACKAGE(CUDA QUIET)
+        IF(CUDA_FOUND)
+
+            IF(UNIX)
+                # GCC 5.3 and above give errors for mempcy from <string.h>
+                # This is a (temporary) fix for that
+                IF("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "5.3.0")
+                    ADD_DEFINITIONS(-D_FORCE_INLINES)
+                ENDIF()
+                # GCC 6.0 and above default to g++14, enabling c++11 features by default
+                # Enabling c++11 with nvcc 7.5 + gcc 6.x doesn't seem to work
+                # Only solution for now is to force use c++03 for gcc 6.x
+                IF("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "6.0.0")
+                    SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler -std=c++98")
+                ENDIF()
+            ENDIF(UNIX)
+
+            INCLUDE_DIRECTORIES(${CUDA_INCLUDE_DIRS})
+
+            FILE(GLOB CUDA_EXAMPLE_SRC_FILES "cuda/*.cu")
+            LIST(SORT CUDA_EXAMPLE_SRC_FILES)
+            FOREACH(FILE ${CUDA_EXAMPLE_SRC_FILES})
+                GET_FILENAME_COMPONENT(EXAMPLE ${FILE} NAME_WE)
+                GET_FILENAME_COMPONENT(FULL_DIR_NAME ${FILE} PATH)
+                GET_FILENAME_COMPONENT(DIR_NAME ${FULL_DIR_NAME} NAME)
+
+                IF(TARGET forge)
+                    BUILD_EXAMPLE(${EXAMPLE} ${FILE} ${DIR_NAME} forge "${CUDA_LIBRARIES}")
+                ELSE(TARGET forge)
+                    BUILD_EXAMPLE(${EXAMPLE} ${FILE} ${DIR_NAME} ${FORGE_LIBRARIES}
+                        "${X11_LIBS};${OPENGL_gl_LIBRARY};${CUDA_LIBRARIES}")
+                ENDIF()
+            ENDFOREACH()
+        ELSE()
+            MESSAGE(STATUS "CUDA Toolkit not found, not building CUDA examples.")
+        ENDIF()
     ENDIF()
-ENDFOREACH()
 
-IF (BUILD_EXAMPLES_CUDA)
-    FIND_PACKAGE(CUDA QUIET)
-    IF(CUDA_FOUND)
+    IF (BUILD_EXAMPLES_OPENCL)
+        FIND_PACKAGE(OpenCL QUIET)
+        IF(OpenCL_FOUND)
+            FILE(GLOB OpenCL_EXAMPLE_SRC_FILES "opencl/*.cpp")
+            LIST(SORT OpenCL_EXAMPLE_SRC_FILES)
+            INCLUDE_DIRECTORIES(
+                "${CMAKE_CURRENT_SOURCE_DIR}/opencl"
+                ${OpenCL_INCLUDE_DIRS}
+                ${CL2HPP_INCLUDE_DIRECTORY}
+                )
+            FOREACH(FILE ${OpenCL_EXAMPLE_SRC_FILES})
+                GET_FILENAME_COMPONENT(EXAMPLE ${FILE} NAME_WE)
+                GET_FILENAME_COMPONENT(FULL_DIR_NAME ${FILE} PATH)
+                GET_FILENAME_COMPONENT(DIR_NAME ${FULL_DIR_NAME} NAME)
 
-        IF(UNIX)
-            # GCC 5.3 and above give errors for mempcy from <string.h>
-            # This is a (temporary) fix for that
-            IF("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "5.3.0")
-                ADD_DEFINITIONS(-D_FORCE_INLINES)
-            ENDIF()
-            # GCC 6.0 and above default to g++14, enabling c++11 features by default
-            # Enabling c++11 with nvcc 7.5 + gcc 6.x doesn't seem to work
-            # Only solution for now is to force use c++03 for gcc 6.x
-            IF("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "6.0.0")
-                SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler -std=c++98")
-            ENDIF()
-        ENDIF(UNIX)
-
-        INCLUDE_DIRECTORIES(${CUDA_INCLUDE_DIRS})
-
-        FILE(GLOB CUDA_EXAMPLE_SRC_FILES "cuda/*.cu")
-        LIST(SORT CUDA_EXAMPLE_SRC_FILES)
-        FOREACH(FILE ${CUDA_EXAMPLE_SRC_FILES})
-            GET_FILENAME_COMPONENT(EXAMPLE ${FILE} NAME_WE)
-            GET_FILENAME_COMPONENT(FULL_DIR_NAME ${FILE} PATH)
-            GET_FILENAME_COMPONENT(DIR_NAME ${FULL_DIR_NAME} NAME)
-
-            IF(TARGET forge)
-                BUILD_EXAMPLE(${EXAMPLE} ${FILE} ${DIR_NAME} forge "${CUDA_LIBRARIES}")
-            ELSE(TARGET forge)
-                BUILD_EXAMPLE(${EXAMPLE} ${FILE} ${DIR_NAME} ${FORGE_LIBRARIES}
-                    "${X11_LIBS};${OPENGL_gl_LIBRARY};${CUDA_LIBRARIES}")
-            ENDIF()
-        ENDFOREACH()
-    ELSE()
-        MESSAGE(STATUS "CUDA Toolkit not found, not building CUDA examples.")
+                IF(TARGET forge)
+                    BUILD_EXAMPLE(${EXAMPLE} ${FILE} ${DIR_NAME} forge "${OpenCL_LIBRARIES};${OPENGL_gl_LIBRARY}")
+                ELSE(TARGET forge)
+                    BUILD_EXAMPLE(${EXAMPLE} ${FILE} ${DIR_NAME} ${FORGE_LIBRARIES}
+                        "${X11_LIBS};${OPENGL_gl_LIBRARY};${OpenCL_LIBRARIES}")
+                ENDIF()
+            ENDFOREACH()
+        ELSE()
+            MESSAGE(STATUS "OpenCL Libraries not found, not building OpenCL examples.")
+        ENDIF()
     ENDIF()
 ENDIF()
 
-IF (BUILD_EXAMPLES_OPENCL)
-    FIND_PACKAGE(OpenCL QUIET)
-    IF(OpenCL_FOUND)
-        FILE(GLOB OpenCL_EXAMPLE_SRC_FILES "opencl/*.cpp")
-        LIST(SORT OpenCL_EXAMPLE_SRC_FILES)
+IF (USE_QT5_WIDGET)
+    set(CMAKE_AUTOMOC ON)
+    IF(Qt5Core_FOUND)
+        set(Qt5_QChartView_EXAMPLE_SRC_FILES
+            qt5Widget/plot3.cpp
+			qt5Widget/plot3Threaded.cpp
+        )
+        LIST(SORT Qt5_QChartView_EXAMPLE_SRC_FILES)
+
+
         INCLUDE_DIRECTORIES(
-            "${CMAKE_CURRENT_SOURCE_DIR}/opencl"
-            ${OpenCL_INCLUDE_DIRS}
-            ${CL2HPP_INCLUDE_DIRECTORY}
+            ${Qt5Core_INCLUDE_DIRS} 
+            ${Qt5Widgets_INCLUDE_DIRS} 
+            ${Qt5Gui_INCLUDE_DIRS} 
+            ${Qt5OpenGL_INCLUDE_DIRS}
             )
-        FOREACH(FILE ${OpenCL_EXAMPLE_SRC_FILES})
+        FOREACH(FILE ${Qt5_QChartView_EXAMPLE_SRC_FILES})
             GET_FILENAME_COMPONENT(EXAMPLE ${FILE} NAME_WE)
             GET_FILENAME_COMPONENT(FULL_DIR_NAME ${FILE} PATH)
             GET_FILENAME_COMPONENT(DIR_NAME ${FULL_DIR_NAME} NAME)
 
+            set(example_sources ${FILE} ${FULL_DIR_NAME}/${EXAMPLE}MainWindow.h ${FULL_DIR_NAME}/${EXAMPLE}MainWindow.cpp)
+
             IF(TARGET forge)
-                BUILD_EXAMPLE(${EXAMPLE} ${FILE} ${DIR_NAME} forge "${OpenCL_LIBRARIES};${OPENGL_gl_LIBRARY}")
+                BUILD_EXAMPLE(${EXAMPLE} "${example_sources}" ${DIR_NAME} forge "Qt5::Core;Qt5::Widgets;Qt5::Gui;Qt5::OpenGL")
             ELSE(TARGET forge)
-                BUILD_EXAMPLE(${EXAMPLE} ${FILE} ${DIR_NAME} ${FORGE_LIBRARIES}
-                    "${X11_LIBS};${OPENGL_gl_LIBRARY};${OpenCL_LIBRARIES}")
+                BUILD_EXAMPLE(${EXAMPLE} "${example_sources}" ${DIR_NAME} ${FORGE_LIBRARIES}
+                    "${X11_LIBS};Qt5::Core;Qt5::Widgets;Qt5::Gui;Qt5::OpenGL")
             ENDIF()
         ENDFOREACH()
     ELSE()
-        MESSAGE(STATUS "OpenCL Libraries not found, not building OpenCL examples.")
+        MESSAGE(STATUS "Qt5 not found, not building Qt5 examples.")
     ENDIF()
 ENDIF()
 

--- a/examples/qt5Widget/plot3.cpp
+++ b/examples/qt5Widget/plot3.cpp
@@ -1,0 +1,20 @@
+/*******************************************************
+ * Copyright (c) 2015-2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include "plot3MainWindow.h"
+#include <QtWidgets/QApplication>
+
+int main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+    Plot3MainWindow mainWindow;
+
+    mainWindow.show();
+    return app.exec();
+}

--- a/examples/qt5Widget/plot3MainWindow.cpp
+++ b/examples/qt5Widget/plot3MainWindow.cpp
@@ -1,0 +1,70 @@
+#include "plot3MainWindow.h"
+
+#include <complex>
+#include <cmath>
+#include <vector>
+#include <iostream>
+
+const unsigned DIMX = 1000;
+const unsigned DIMY = 800;
+
+static const float ZMIN = 0.1f;
+static const float ZMAX = 10.f;
+
+const float DX = 0.005f;
+const size_t ZSIZE = (ZMAX-ZMIN)/DX+1;
+
+using namespace std;
+
+void generateCurve(float t, float dx, std::vector<float> &vec )
+{
+    vec.clear();
+    
+    for (int i=0; i < (int)ZSIZE; ++i)
+    {
+        float z = ZMIN + i*dx;
+        vec.push_back(cos(z*t+t)/z);
+        vec.push_back(sin(z*t+t)/z);
+        vec.push_back(z+0.1*sin(t));
+    }
+}
+
+Plot3MainWindow::Plot3MainWindow(QWidget *parent, Qt::WindowFlags flags)
+{
+    m_chart=new forge::ChartWidget(FG_CHART_3D);
+    
+    m_chart->setAxesLabelFormat("%3.1f", "%3.1f", "%.2e");
+    m_chart->setAxesLimits(-1.1f, 1.1f, -1.1f, 1.1f, 0.f, 10.f);
+    m_chart->setAxesTitles("x-axis", "y-axis", "z-axis");
+    
+    m_plot=std::unique_ptr<forge::Plot>(new forge::Plot(m_chart->plot(ZSIZE, forge::f32)));
+    
+    createGLBuffer(&m_functionHandle, m_plot->vertices(), FORGE_VERTEX_BUFFER);
+    
+    m_time=0.0f;
+    generateCurve(m_time, DX, m_function);
+    copyToGLBuffer(m_functionHandle, (ComputeResourceHandle)m_function.data(), m_plot->verticesSize());
+    
+    setCentralWidget(m_chart);
+            
+    m_drawTimer=new QTimer(this);
+    
+    bool connected=connect(m_drawTimer, SIGNAL(timeout()), this, SLOT(draw()));
+    m_drawTimer->start(0);
+
+    resize(400,400);
+}
+
+Plot3MainWindow::~Plot3MainWindow()
+{
+    m_drawTimer->stop();
+    releaseGLBuffer(m_functionHandle);
+}
+
+void Plot3MainWindow::draw()
+{
+    m_time+=0.01f;
+    generateCurve(m_time, DX, m_function);
+    copyToGLBuffer(m_functionHandle, (ComputeResourceHandle)m_function.data(), m_plot->verticesSize());
+    m_chart->render();
+}

--- a/examples/qt5Widget/plot3MainWindow.h
+++ b/examples/qt5Widget/plot3MainWindow.h
@@ -1,0 +1,34 @@
+#ifndef _Plot3MainWindow_h_
+#define _Plot3MainWindow_h_
+
+#include <QtWidgets/QMainWindow>
+#include <QtCore/QTimer>
+
+#include <forge.h>
+
+#define USE_FORGE_CPU_COPY_HELPERS
+#include <ComputeCopy.h>
+
+class Plot3MainWindow: public QMainWindow
+{
+    Q_OBJECT
+
+public:
+    Plot3MainWindow(QWidget *parent=0, Qt::WindowFlags flags=0);
+    ~Plot3MainWindow();
+
+public slots:
+    void draw();
+
+private:
+    forge::ChartWidget *m_chart;
+    std::unique_ptr<forge::Plot> m_plot;
+
+    QTimer *m_drawTimer;
+
+    GfxHandle *m_functionHandle;
+    std::vector<float> m_function;
+    float m_time;
+};
+
+#endif //_Plot3MainWindow_h_

--- a/examples/qt5Widget/plot3Threaded.cpp
+++ b/examples/qt5Widget/plot3Threaded.cpp
@@ -1,0 +1,20 @@
+/*******************************************************
+ * Copyright (c) 2015-2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include "plot3ThreadedMainWindow.h"
+#include <QtWidgets/QApplication>
+
+int main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+    Plot3ThreadedMainWindow mainWindow;
+
+    mainWindow.show();
+    return app.exec();
+}

--- a/examples/qt5Widget/plot3ThreadedMainWindow.cpp
+++ b/examples/qt5Widget/plot3ThreadedMainWindow.cpp
@@ -1,0 +1,122 @@
+#include "plot3ThreadedMainWindow.h"
+
+#include <complex>
+#include <cmath>
+#include <vector>
+#include <iostream>
+
+const unsigned DIMX = 1000;
+const unsigned DIMY = 800;
+
+static const float ZMIN = 0.1f;
+static const float ZMAX = 10.f;
+
+const float DX = 0.005f;
+const size_t ZSIZE = (ZMAX-ZMIN)/DX+1;
+
+using namespace std;
+
+void generateCurve(float t, float dx, std::vector<float> &vec )
+{
+    vec.clear();
+    
+    for (int i=0; i < (int)ZSIZE; ++i)
+    {
+        float z = ZMIN + i*dx;
+        vec.push_back(cos(z*t+t)/z);
+        vec.push_back(sin(z*t+t)/z);
+        vec.push_back(z+0.1*sin(t));
+    }
+}
+
+Plot3ThreadedMainWindow::Plot3ThreadedMainWindow(QWidget *parent, Qt::WindowFlags flags):
+m_qtDrawThread(nullptr)
+{
+    m_chart=new forge::ChartWidget(FG_CHART_3D, nullptr, true);
+    setCentralWidget(m_chart);
+            
+    m_contextMoved=false;
+    m_stopThread=false;
+    m_drawThread=std::thread(std::bind(&Plot3ThreadedMainWindow::draw, this));
+
+    //This could be done with a QThread but I prefer std::thread
+    //so there is a bit of a dance to get them in sync because
+    //only the ui thread can move the context and a QThread
+    //cannot be created from a std::thread
+
+    //You could also skip all this and create the opengl context in the
+    //thread and use ChartWidget.setThreadContext()
+
+    //if you are not familar with threads, condition_variable's wait 
+    //releases the lock while waiting
+    {
+        //wait for thread to set qtDrawThread
+        std::unique_lock<std::mutex> lock(m_qtDrawThreadMutex);
+
+        while(m_qtDrawThread==nullptr)
+            m_qtDrawThreadEvent.wait(lock);
+
+        //now need to move the chart opengl context to the thread
+        m_chart->context()->moveToThread(m_qtDrawThread);
+
+        //now notify thread it is safe to proceed
+        m_contextMoved=true;
+    }
+    m_qtDrawThreadMoved.notify_all();
+
+    resize(400,400);
+}
+
+Plot3ThreadedMainWindow::~Plot3ThreadedMainWindow()
+{
+    m_stopThread=true;
+    m_drawThread.join();
+}
+
+void Plot3ThreadedMainWindow::draw()
+{
+    {
+        std::unique_lock<std::mutex> lock(m_qtDrawThreadMutex);
+
+        //get qt thread, and notify ui thread we have it
+        m_qtDrawThread=QThread::currentThread();
+        m_qtDrawThreadEvent.notify_all();
+
+        //wait for ui thread to move the context
+        while(!m_contextMoved)
+            m_qtDrawThreadMoved.wait(lock);
+    }
+
+    std::unique_ptr<forge::Plot> plot;
+    GfxHandle *functionHandle;
+    std::vector<float> function;
+    float time;
+
+    //make sure context is set for thread
+    m_chart->makeCurrent();
+
+    //intialize chart
+    m_chart->initialize();
+
+    m_chart->setAxesLabelFormat("%3.1f", "%3.1f", "%.2e");
+    m_chart->setAxesLimits(-1.1f, 1.1f, -1.1f, 1.1f, 0.f, 10.f);
+    m_chart->setAxesTitles("x-axis", "y-axis", "z-axis");
+
+    plot=std::unique_ptr<forge::Plot>(new forge::Plot(m_chart->plot(ZSIZE, forge::f32)));
+
+    createGLBuffer(&functionHandle, plot->vertices(), FORGE_VERTEX_BUFFER);
+
+    time=0.0f;
+    while(!m_stopThread)
+    {
+        generateCurve(time, DX, function);
+        copyToGLBuffer(functionHandle, (ComputeResourceHandle)function.data(), plot->verticesSize());
+        m_chart->render();
+        time+=0.01f;
+    }
+
+    //break down chart
+    m_chart->terminate();
+
+    releaseGLBuffer(functionHandle);
+}

--- a/examples/qt5Widget/plot3ThreadedMainWindow.h
+++ b/examples/qt5Widget/plot3ThreadedMainWindow.h
@@ -1,0 +1,39 @@
+#ifndef _Plot3ThreadedMainWindow_h_
+#define _Plot3ThreadedMainWindow_h_
+
+#include <QtWidgets/QMainWindow>
+#include <QtCore/QThread>
+
+#include <forge.h>
+
+#define USE_FORGE_CPU_COPY_HELPERS
+#include <ComputeCopy.h>
+
+#include <thread>
+
+class Plot3ThreadedMainWindow: public QMainWindow
+{
+    Q_OBJECT
+
+public:
+    Plot3ThreadedMainWindow(QWidget *parent=0, Qt::WindowFlags flags=0);
+    ~Plot3ThreadedMainWindow();
+
+public slots:
+    void draw();
+
+private:
+    forge::ChartWidget *m_chart;
+    
+    std::atomic<bool> m_stopThread;
+    std::thread m_drawThread;
+
+    QThread *m_qtDrawThread;
+    std::condition_variable m_qtDrawThreadEvent;
+    std::condition_variable m_qtDrawThreadMoved;
+    std::mutex m_qtDrawThreadMutex;
+
+    bool m_contextMoved;
+};
+
+#endif //_Plot3ThreadedMainWindow_h_

--- a/include/fg/chart.h
+++ b/include/fg/chart.h
@@ -328,9 +328,27 @@ FGAPI fg_err fg_remove_vector_field_from_chart(fg_chart pHandle, fg_vector_field
 
    \return \ref fg_err error code
  */
+#ifdef FG_WINDOW_TOOLKIT
 FGAPI fg_err fg_render_chart(const fg_window pWindow,
                              const fg_chart pChart,
                              const int pX, const int pY, const int pWidth, const int pHeight);
+#endif //FG_WINDOW_TOOLKIT
+
+/**
+Render the chart to given window id
+
+\param[in] windowId is target window's id to where chart will be rendered
+\param[in] pChart is chart handle
+\param[in] pX is x coordinate of origin of viewport in window coordinates
+\param[in] pY is y coordinate of origin of viewport in window coordinates
+\param[in] pWidth is the width of the viewport
+\param[in] pHeight is the height of the viewport
+
+\return \ref fg_err error code
+*/
+FGAPI fg_err fg_render_chart_to_id(const int windowId,
+    const fg_chart pChart,
+    const int pX, const int pY, const int pWidth, const int pHeight);
 
 /**
    Render the type of a chart
@@ -586,9 +604,22 @@ class Chart {
            \param[in] pVPW is the width of the viewport
            \param[in] pVPH is the height of the viewport
          */
+#ifdef FG_WINDOW_TOOLKIT
         FGAPI void render(const Window& pWindow,
                           const int pX, const int pY, const int pVPW, const int pVPH) const;
+#endif //FG_WINDOW_TOOLKIT
 
+        /**
+        Render the chart to given window id
+
+        \param[in] windowId is target window id to where chart will be rendered
+        \param[in] pX is x coordinate of origin of viewport in window coordinates
+        \param[in] pY is y coordinate of origin of viewport in window coordinates
+        \param[in] pVPW is the width of the viewport
+        \param[in] pVPH is the height of the viewport
+        */
+        FGAPI void render(const int windowId,
+                          const int pX, const int pY, const int pVPW, const int pVPH) const;
         /**
            Get the handle to internal implementation of Chart
          */

--- a/include/fg/chart.h
+++ b/include/fg/chart.h
@@ -267,6 +267,56 @@ FGAPI fg_err fg_add_vector_field_to_chart(fg_vector_field* pField, fg_chart pHan
                                           const unsigned pNPoints, const fg_dtype pType);
 
 /**
+Remove an Image object from the current chart
+
+\param[in] pHandle is chart handle to which image object will be added.
+\param[in] pImage is the handle of the image object to remove
+
+\return \ref fg_err error code
+*/
+FGAPI fg_err fg_remove_image_from_chart(fg_chart pHandle, fg_image pImage);
+
+/**
+Remove a Histogram object from the current chart
+
+\param[in] pHandle is chart handle
+\param[in] pHistogram is the handle of the histogram object to remove
+
+\return \ref fg_err error code
+*/
+FGAPI fg_err fg_remove_histogram_from_chart(fg_chart pHandle, fg_histogram pHistogram);
+
+/**
+Remove a Plot object from the current chart
+
+\param[in] pHandle is chart handle
+\param[in] pPlot is the handle of the plot object to remove
+
+\return \ref fg_err error code
+*/
+FGAPI fg_err fg_remove_plot_from_chart(fg_chart pHandle, fg_plot pPlot);
+
+/**
+Remove a Plot object from the current chart
+
+\param[in] pHandle is chart handle
+\param[in] pSurface is the handle of the surface object to remove
+
+\return \ref fg_err error code
+*/
+FGAPI fg_err fg_remove_surface_from_chart(fg_chart pHandle, fg_surface pSurface);
+
+/**
+Remove a Vector Field object from the current chart
+
+\param[in] pHandle is chart handle
+\param[in] pField is the handle of the Vector Field object to remove
+
+\return \ref fg_err error code
+*/
+FGAPI fg_err fg_remove_vector_field_from_chart(fg_chart pHandle, fg_vector_field pField);
+
+/**
    Render the chart to given window
 
    \param[in] pWindow is target window to where chart will be rendered
@@ -432,6 +482,41 @@ class Chart {
            \param[in] pVectorField is the Surface to render on the chart
          */
         FGAPI void add(const VectorField& pVectorField);
+
+        /**
+        Remove an existing Image object to the current chart
+
+        \param[in] pImage is the Image to remove from the chart
+        */
+        FGAPI void remove(const Image& pImage);
+
+        /**
+        Remove an existing Histogram object to the current chart
+
+        \param[in] pHistogram is the Histogram to remove from the chart
+        */
+        FGAPI void remove(const Histogram& pHistogram);
+
+        /**
+        Remove an existing Plot object to the current chart
+
+        \param[in] pPlot is the Plot to remove from the chart
+        */
+        FGAPI void remove(const Plot& pPlot);
+
+        /**
+        Remove an existing Surface object to the current chart
+
+        \param[in] pSurface is the Surface to remove from the chart
+        */
+        FGAPI void remove(const Surface& pSurface);
+
+        /**
+        Remove an existing vector field object to the current chart
+
+        \param[in] pVectorField is the Vectore to remove from the chart
+        */
+        FGAPI void remove(const VectorField& pVectorField);
 
         /**
            Create and add an Image object to the current chart

--- a/include/fg/chartWidget.h
+++ b/include/fg/chartWidget.h
@@ -1,0 +1,293 @@
+#ifndef _QChartWidget_h_
+#define _QChartWidget_h_
+
+#ifndef Q_MOC_RUN
+#endif //Q_MOC_RUN
+
+#include <QtOpenGL/QGLWidget>
+#include <QtGui/QImage>
+
+#include <fg/defines.h>
+#include <fg/chart.h>
+
+#include <atomic>
+#include <thread>
+#include <condition_variable>
+
+namespace forge
+{
+
+class FGAPI ChartWidget: public QGLWidget
+{
+    Q_OBJECT
+
+public:
+    ChartWidget(forge::ChartType chartType, QWidget *parent=nullptr, bool threaded=false);
+    ChartWidget(forge::ChartType chartType, QGLContext *context, QWidget *parent=nullptr, bool threaded=false);
+    ~ChartWidget();
+
+    /**
+    Set axes titles for the chart
+
+    \param[in] pX is x-axis title label
+    \param[in] pY is y-axis title label
+    \param[in] pZ is z-axis title label
+    */
+    void setAxesTitles(const char* pX,
+        const char* pY,
+        const char* pZ=NULL);
+
+    /**
+    Set axes data ranges
+
+    \param[in] pXmin is x-axis minimum data value
+    \param[in] pXmax is x-axis maximum data value
+    \param[in] pYmin is y-axis minimum data value
+    \param[in] pYmax is y-axis maximum data value
+    \param[in] pZmin is z-axis minimum data value
+    \param[in] pZmax is z-axis maximum data value
+    */
+    void setAxesLimits(const float pXmin, const float pXmax,
+        const float pYmin, const float pYmax,
+        const float pZmin=0, const float pZmax=0);
+
+    /**
+    Set the format for display of axes labels
+
+    \param[in] pXFormat sets the display format for numbers of X axis
+    \param[in] pYFormat sets the display format for numbers of Y axis
+    \param[in] pZFormat sets the display format for numbers of Z axis
+
+    Display format string follows printf style formating for numbers
+    */
+    void setAxesLabelFormat(const char* pXFormat,
+        const char* pYFormat="%4.1f",
+        const char* pZFormat="%4.1f");
+
+    /**
+    Get axes data ranges
+
+    \param[out] pXmin is x-axis minimum data value
+    \param[out] pXmax is x-axis maximum data value
+    \param[out] pYmin is y-axis minimum data value
+    \param[out] pYmax is y-axis maximum data value
+    \param[out] pZmin is z-axis minimum data value
+    \param[out] pZmax is z-axis maximum data value
+    */
+    void getAxesLimits(float* pXmin, float* pXmax,
+        float* pYmin, float* pYmax,
+        float* pZmin=NULL, float* pZmax=NULL);
+
+    /**
+    Set legend position for Chart
+
+    \param[in] pX is horizontal position in normalized coordinates
+    \param[in] pY is vertical position in normalized coordinates
+
+    \note By normalized coordinates, the range of these coordinates is expected to be [0-1].
+    (0,0) is the bottom hand left corner.
+    */
+    void setLegendPosition(const float pX, const float pY);
+
+    /**
+    Add an existing Image object to the current chart
+
+    \param[in] pImage is the Image to render on the chart
+    */
+    void add(const Image& pImage);
+
+    /**
+    Add an existing Histogram object to the current chart
+
+    \param[in] pHistogram is the Histogram to render on the chart
+    */
+    void add(const Histogram& pHistogram);
+
+    /**
+    Add an existing Plot object to the current chart
+
+    \param[in] pPlot is the Plot to render on the chart
+    */
+    void add(const Plot& pPlot);
+
+    /**
+    Add an existing Surface object to the current chart
+
+    \param[in] pSurface is the Surface to render on the chart
+    */
+    void add(const Surface& pSurface);
+
+    /**
+    Add an existing vector field object to the current chart
+
+    \param[in] pVectorField is the Surface to render on the chart
+    */
+    void add(const VectorField& pVectorField);
+
+    /**
+    Remove an existing Image object from the current chart
+
+    \param[in] pImage is the Image to remove from the chart
+    */
+    void remove(const Image& pImage);
+
+    /**
+    Remove an existing Histogram object from the current chart
+
+    \param[in] pHistogram is the Histogram to remove from the chart
+    */
+    void remove(const Histogram& pHistogram);
+
+    /**
+    Remove an existing Plot object from the current chart
+
+    \param[in] pPlot is the Plot to remove from the chart
+    */
+    void remove(const Plot& pPlot);
+
+    /**
+    Remove an existing Surface object from the current chart
+
+    \param[in] pSurface is the Surface to remove from the chart
+    */
+    void remove(const Surface& pSurface);
+
+    /**
+    Remove an existing vector field object from the current chart
+
+    \param[in] pVectorField is the Surface to remove from the chart
+    */
+    void remove(const VectorField& pVectorField);
+
+    /**
+    Create and add an Image object to the current chart
+
+    \param[in] pWidth Width of the image
+    \param[in] pHeight Height of the image
+    \param[in] pFormat Color channel format of image, uses one of the values
+    of \ref ChannelFormat
+    \param[in] pDataType takes one of the values of \ref dtype that indicates
+    the integral data type of histogram data
+    */
+    Image image(const unsigned pWidth, const unsigned pHeight,
+        const ChannelFormat pFormat=FG_RGBA, const dtype pDataType=f32);
+
+    /**
+    Create and add an Histogram object to the current chart
+
+    \param[in] pNBins is number of bins the data is sorted out
+    \param[in] pDataType takes one of the values of \ref dtype that indicates
+    the integral data type of histogram data
+    */
+    Histogram histogram(const unsigned pNBins, const dtype pDataType);
+
+    /**
+    Create and add an Plot object to the current chart
+
+    \param[in] pNumPoints is number of data points to display
+    \param[in] pDataType takes one of the values of \ref dtype that indicates
+    the integral data type of plot data
+    \param[in] pPlotType dictates the type of plot/graph,
+    it can take one of the values of \ref PlotType
+    \param[in] pMarkerType indicates which symbol is rendered as marker. It can take one of
+    the values of \ref MarkerType.
+    */
+    Plot plot(const unsigned pNumPoints, const dtype pDataType,
+        const PlotType pPlotType=FG_PLOT_LINE, const MarkerType pMarkerType=FG_MARKER_NONE);
+
+    /**
+    Create and add an Plot object to the current chart
+
+    \param[in] pNumXPoints is number of data points along X dimension
+    \param[in] pNumYPoints is number of data points along Y dimension
+    \param[in] pDataType takes one of the values of \ref dtype that indicates
+    the integral data type of plot data
+    \param[in] pPlotType is the render type which can be one of \ref PlotType (valid choices
+    are FG_PLOT_SURFACE and FG_PLOT_SCATTER)
+    \param[in] pMarkerType is the type of \ref MarkerType to draw for \ref FG_PLOT_SCATTER plot type
+    */
+    Surface surface(const unsigned pNumXPoints, const unsigned pNumYPoints, const dtype pDataType,
+        const PlotType pPlotType=FG_PLOT_SURFACE, const MarkerType pMarkerType=FG_MARKER_NONE);
+
+    /**
+    Create and add an Vector Field object to the current chart
+
+    \param[in] pNumPoints is number of data points to display
+    \param[in] pDataType takes one of the values of \ref dtype that indicates
+    the integral data type of vector field data
+    */
+    VectorField vectorField(const unsigned pNumPoints, const dtype pDataType);
+
+    /**
+    Sets widgets opengl context
+    */
+    void setThreadContext(QGLContext *glContext);
+
+    /**
+    Intializes widget when used in threaded mode
+    */
+    void initialize();
+
+    /**
+    Breaks down widget when used in threaded mode
+    */
+    void terminate();
+
+    /**
+    Render the chart to the widget
+    */
+    void render();
+
+    /**
+    Notifies wait event
+    */
+    void update();
+
+    /**
+    Waits for update notification (resize, move, screen refresh) or timeout, return true it wait succeeded or false if timeout
+
+    \param[in] timeout time in milliseconds to wait for update event before timingout
+    */
+    bool waitEvent(unsigned int timeout);
+
+protected:
+    bool event(QEvent *e);
+
+    virtual void glInit();
+    virtual void glDraw();
+
+    virtual void initializeGL();
+    virtual void resizeGL(int width, int height);
+    virtual void paintGL();
+
+    virtual void resizeEvent(QResizeEvent *evt);
+    virtual void closeEvent(QCloseEvent *evt);
+
+
+
+private:
+    void resize();
+    void renderInternal();
+
+    void mousePressEvent(QMouseEvent* event);
+    void mouseReleaseEvent(QMouseEvent* event);
+    void mouseMoveEvent(QMouseEvent* event);
+
+    int m_windowsId;
+    forge::ChartType m_chartType;
+    std::unique_ptr<forge::Chart> m_chart;
+    bool m_threaded;
+
+    std::atomic<bool> m_init;
+    std::atomic<bool> m_resize;
+
+    std::mutex m_mutex;
+    std::condition_variable m_waitEvent;
+
+    QPoint m_leftClick;
+    QPoint m_rightClick;
+};
+
+}//namespace forge
+
+#endif //_QChartWidget_h_

--- a/include/fg/defines.h
+++ b/include/fg/defines.h
@@ -37,7 +37,10 @@
 
 #include <cstdlib>
 
+#ifdef FG_WINDOW_TOOLKIT
 typedef void* fg_window;
+#endif //FG_WINDOW_TOOLKIT
+
 typedef void* fg_font;
 typedef void* fg_chart;
 typedef void* fg_image;

--- a/include/fg/image.h
+++ b/include/fg/image.h
@@ -148,10 +148,27 @@ FGAPI fg_err fg_get_image_size(unsigned* pOut, const fg_image pImage);
 
    \return \ref fg_err error code
  */
+#ifdef FG_WINDOW_TOOLKIT
 FGAPI fg_err fg_render_image(const fg_window pWindow,
                              const fg_image pImage,
                              const int pX, const int pY, const int pWidth, const int pHeight);
+#endif //FG_WINDOW_TOOLKIT
 
+/**
+    Render the image to given window id
+    
+    \param[in] windowId is target window id to where image will be rendered
+    \param[in] pImage is the image handle
+    \param[in] pX is x coordinate of origin of viewport in window coordinates
+    \param[in] pY is y coordinate of origin of viewport in window coordinates
+    \param[in] pWidth is the width of the viewport
+    \param[in] pHeight is the height of the viewport
+    
+    \return \ref fg_err error code
+*/
+FGAPI fg_err fg_render_image_to_id(const int windowId,
+                                   const fg_image pImage,
+                                   const int pX, const int pY, const int pWidth, const int pHeight);
 /** @} */
 
 #ifdef __cplusplus
@@ -272,7 +289,21 @@ class Image {
            \param[in] pVPW is the width of the viewport
            \param[in] pVPH is the height of the viewport
          */
+#ifdef FG_WINDOW_TOOLKIT
         FGAPI void render(const Window& pWindow,
+                          const int pX, const int pY, const int pVPW, const int pVPH) const;
+#endif //FG_WINDOW_TOOLKIT
+
+        /**
+        Render the image to given window id
+
+        \param[in] windowId is target window id to where image will be rendered
+        \param[in] pX is x coordinate of origin of viewport in window coordinates
+        \param[in] pY is y coordinate of origin of viewport in window coordinates
+        \param[in] pVPW is the width of the viewport
+        \param[in] pVPH is the height of the viewport
+        */
+        FGAPI void render(const int windowId,
                           const int pX, const int pY, const int pVPW, const int pVPH) const;
 
         /**

--- a/include/fg/window.h
+++ b/include/fg/window.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#ifdef FG_WINDOW_TOOLKIT
+
 #include <fg/defines.h>
 #include <fg/font.h>
 #include <fg/image.h>
@@ -507,3 +509,4 @@ class Window {
 }
 
 #endif
+#endif //FG_WINDOW_TOOLKIT

--- a/include/forge.h
+++ b/include/forge.h
@@ -30,6 +30,8 @@ they are related to.
 
 */
 
+#include "fg/config.h"
+
 #include "fg/defines.h"
 #include "fg/util.h"
 #include "fg/exception.h"
@@ -40,3 +42,7 @@ they are related to.
 #include "fg/plot.h"
 #include "fg/surface.h"
 #include "fg/histogram.h"
+
+#ifdef USE_QT5_WIDGET
+#include "fg/chartWidget.h"
+#endif //USE_QT5_WIDGET

--- a/src/api/c/chart.cpp
+++ b/src/api/c/chart.cpp
@@ -321,6 +321,90 @@ fg_err fg_add_vector_field_to_chart(fg_vector_field* pField, fg_chart pChart,
     return FG_ERR_NONE;
 }
 
+
+fg_err fg_remove_image_from_chart(fg_chart pChart, fg_image pImage)
+{
+    try
+    {
+        ARG_ASSERT(0, (pChart!=0));
+        ARG_ASSERT(1, (pImage!=0));
+
+        common::Image* img=getImage(pImage);
+        getChart(pChart)->removeRenderable(img->impl());
+    }
+    CATCHALL
+
+        return FG_ERR_NONE;
+}
+
+fg_err fg_remove_histogram_from_chart(fg_chart pChart, fg_histogram pHistogram)
+{
+    try
+    {
+        ARG_ASSERT(0, (pHistogram!=0));
+        ARG_ASSERT(1, (pChart!=0));
+       
+        common::Chart* chrt=getChart(pChart);
+
+        common::Histogram* hist=getHistogram(pHistogram);
+        chrt->removeRenderable(hist->impl());
+    }
+    CATCHALL
+
+        return FG_ERR_NONE;
+}
+
+fg_err fg_remove_plot_from_chart(fg_chart pChart, fg_plot pPlot)
+{
+    try
+    {
+        ARG_ASSERT(0, (pPlot!=0));
+        ARG_ASSERT(1, (pChart!=0));
+
+        common::Chart* chrt=getChart(pChart);
+
+        common::Plot* plt=getPlot(pPlot);
+        chrt->removeRenderable(plt->impl());
+
+    }
+    CATCHALL
+
+        return FG_ERR_NONE;
+}
+
+fg_err fg_remove_surface_from_chart(fg_chart pChart, fg_surface pSurface)
+{
+    try
+    {
+        ARG_ASSERT(0, (pSurface!=0));
+        ARG_ASSERT(1, (pChart!=0));
+
+        common::Chart* chrt=getChart(pChart);
+
+        common::Surface* surf=getSurface(pSurface);
+        chrt->removeRenderable(surf->impl());
+    }
+    CATCHALL
+
+        return FG_ERR_NONE;
+}
+
+fg_err fg_remove_vector_field_from_chart(fg_chart pChart, fg_vector_field pField)
+{
+    try
+    {
+        ARG_ASSERT(0, (pField!=0));
+        ARG_ASSERT(1, (pChart!=0));
+
+        common::Chart* chrt=getChart(pChart);
+        common::VectorField* field=getVectorField(pField);
+        chrt->removeRenderable(field->impl());
+    }
+    CATCHALL
+
+        return FG_ERR_NONE;
+}
+
 fg_err fg_render_chart(const fg_window pWindow, const fg_chart pChart,
                        const int pX, const int pY, const int pWidth, const int pHeight)
 {

--- a/src/api/c/chart.cpp
+++ b/src/api/c/chart.cpp
@@ -405,6 +405,7 @@ fg_err fg_remove_vector_field_from_chart(fg_chart pChart, fg_vector_field pField
         return FG_ERR_NONE;
 }
 
+#ifdef FG_WINDOW_TOOLKIT
 fg_err fg_render_chart(const fg_window pWindow, const fg_chart pChart,
                        const int pX, const int pY, const int pWidth, const int pHeight)
 {
@@ -423,6 +424,27 @@ fg_err fg_render_chart(const fg_window pWindow, const fg_chart pChart,
     CATCHALL
 
     return FG_ERR_NONE;
+}
+#endif //FG_WINDOW_TOOLKIT
+
+fg_err fg_render_chart_to_id(const int windowId, const fg_chart pChart,
+    const int pX, const int pY, const int pWidth, const int pHeight)
+{
+    try
+    {
+        ARG_ASSERT(1, (pChart!=0));
+        ARG_ASSERT(2, (pX>=0));
+        ARG_ASSERT(3, (pY>=0));
+        ARG_ASSERT(4, (pWidth>0));
+        ARG_ASSERT(5, (pHeight>0));
+
+        getChart(pChart)->render(windowId,
+            pX, pY, pWidth, pHeight,
+            IDENTITY, IDENTITY);
+    }
+    CATCHALL
+
+        return FG_ERR_NONE;
 }
 
 fg_err fg_get_chart_type(fg_chart_type *pChartType, const fg_chart pChart)

--- a/src/api/c/image.cpp
+++ b/src/api/c/image.cpp
@@ -152,6 +152,7 @@ fg_err fg_get_image_size(unsigned* pOut, const fg_image pImage)
     return FG_ERR_NONE;
 }
 
+#ifdef FG_WINDOW_TOOLKIT
 fg_err fg_render_image(const fg_window pWindow,
                        const fg_image pImage,
                        const int pX, const int pY, const int pWidth, const int pHeight)
@@ -171,4 +172,26 @@ fg_err fg_render_image(const fg_window pWindow,
     CATCHALL
 
     return FG_ERR_NONE;
+}
+#endif //FG_WINDOW_TOOLKIT
+
+fg_err fg_render_image_to_id(const int windowId,
+    const fg_image pImage,
+    const int pX, const int pY, const int pWidth, const int pHeight)
+{
+    try
+    {
+        ARG_ASSERT(1, (pImage!=0));
+        ARG_ASSERT(2, (pX>=0));
+        ARG_ASSERT(3, (pY>=0));
+        ARG_ASSERT(4, (pWidth>0));
+        ARG_ASSERT(5, (pHeight>0));
+
+        getImage(pImage)->render(windowId,
+            pX, pY, pWidth, pHeight,
+            IDENTITY, IDENTITY);
+    }
+    CATCHALL
+
+        return FG_ERR_NONE;
 }

--- a/src/api/c/window.cpp
+++ b/src/api/c/window.cpp
@@ -7,6 +7,8 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#ifdef FG_WINDOW_TOOLKIT
+
 #include <fg/window.h>
 
 #include <err_common.hpp>
@@ -291,3 +293,5 @@ fg_err fg_save_window_framebuffer(const char* pFullPath, const fg_window pWindow
     CATCHALL
     return FG_ERR_NONE;
 }
+
+#endif //FG_WINDOW_TOOLKIT

--- a/src/api/cpp/chart.cpp
+++ b/src/api/cpp/chart.cpp
@@ -162,10 +162,18 @@ VectorField Chart::vectorField(const unsigned pNumPoints, const dtype pDataType)
     return VectorField(temp);
 }
 
+#ifdef FG_WINDOW_TOOLKIT
 void Chart::render(const Window& pWindow,
                    const int pX, const int pY, const int pVPW, const int pVPH) const
 {
     FG_THROW(fg_render_chart(pWindow.get(), get(), pX, pY, pVPW, pVPH));
+}
+#endif //FG_WINDOW_TOOLKIT
+
+void Chart::render(const int windowId,
+    const int pX, const int pY, const int pVPW, const int pVPH) const
+{
+    FG_THROW(fg_render_chart_to_id(windowId, get(), pX, pY, pVPW, pVPH));
 }
 
 fg_chart Chart::get() const

--- a/src/api/cpp/chart.cpp
+++ b/src/api/cpp/chart.cpp
@@ -97,6 +97,31 @@ void Chart::add(const VectorField& pVectorField)
     FG_THROW(fg_append_vector_field_to_chart(get(), pVectorField.get()));
 }
 
+void Chart::remove(const Image& pImage)
+{
+    FG_THROW(fg_remove_image_from_chart(get(), pImage.get()));
+}
+
+void Chart::remove(const Histogram& pHistogram)
+{
+    FG_THROW(fg_remove_histogram_from_chart(get(), pHistogram.get()));
+}
+
+void Chart::remove(const Plot& pPlot)
+{
+    FG_THROW(fg_remove_plot_from_chart(get(), pPlot.get()));
+}
+
+void Chart::remove(const Surface& pSurface)
+{
+    FG_THROW(fg_remove_surface_from_chart(get(), pSurface.get()));
+}
+
+void Chart::remove(const VectorField& pVectorField)
+{
+    FG_THROW(fg_remove_vector_field_from_chart(get(), pVectorField.get()));
+}
+
 Image Chart::image(const unsigned pWidth, const unsigned pHeight,
                    const ChannelFormat pFormat, const dtype pDataType)
 {

--- a/src/api/cpp/chartWidget.cpp
+++ b/src/api/cpp/chartWidget.cpp
@@ -298,6 +298,7 @@ void ChartWidget::setThreadContext(QGLContext *glContext)
         FG_ERROR("Chart is not setup for threading, this function should not be called", FG_ERR_INTERNAL);
 
     setContext(glContext, nullptr, false);
+    makeCurrent();
     initialize();
 }
 
@@ -340,6 +341,8 @@ void ChartWidget::render()
 
     if(m_resize)
         resize();
+
+    makeCurrent();
 
     glViewport(0, 0, width(), height());
 

--- a/src/api/cpp/chartWidget.cpp
+++ b/src/api/cpp/chartWidget.cpp
@@ -1,0 +1,394 @@
+#include "fg/chart.h"
+#include "handle.hpp"
+
+#include "fg/chartWidget.h"
+
+#include <QtGui/QImage>
+#include <QtGui/QMouseEvent>
+#include <QtCore/QThread>
+#include <QtGui/QOpenGlContext>
+#include <QtPlatformHeaders/QWGLNativeContext>
+#include <QtGui/QWindow>
+
+#include <gl_native_handles.hpp>
+
+using namespace std::chrono_literals;
+
+namespace forge
+{
+extern int getNextUniqueId();
+
+ChartWidget::ChartWidget(forge::ChartType chartType, QWidget *parent, bool threaded):
+QGLWidget(parent),
+m_init(false),
+m_threaded(threaded),
+m_windowsId(getNextUniqueId()),
+m_chartType(chartType)
+{
+    if(!threaded)
+    {
+        makeCurrent();
+        initialize();
+    }
+    else
+        doneCurrent();
+}
+
+ChartWidget::ChartWidget(forge::ChartType chartType, QGLContext *context, QWidget *parent, bool threaded):
+QGLWidget(context, parent),
+m_init(false),
+m_threaded(threaded),
+m_windowsId(getNextUniqueId()),
+m_chartType(chartType)
+{
+    if(!threaded)
+    {
+        makeCurrent();
+        initialize();
+    }
+    else
+        doneCurrent();
+}
+
+ChartWidget::~ChartWidget()
+{
+    //if you hit this then you created the widget with threading
+    //but didn't call terminate() before it was destroyed
+    if(m_threaded && m_init)
+        FG_ERROR("Chart has been created as threaded but terminate() has not been called before it was destroyed", FG_ERR_INTERNAL);
+}
+void ChartWidget::setAxesTitles(const char* pX, const char* pY, const char* pZ)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    m_chart->setAxesTitles(pX, pY, pZ);
+}
+
+void ChartWidget::setAxesLimits(const float pXmin, const float pXmax,
+    const float pYmin, const float pYmax,
+    const float pZmin, const float pZmax)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    m_chart->setAxesLimits(pXmin, pXmax, pYmin, pYmax, pZmin, pZmax);
+}
+
+void ChartWidget::setAxesLabelFormat(const char* pXFormat,
+    const char* pYFormat,
+    const char* pZFormat)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    m_chart->setAxesLabelFormat(pXFormat, pYFormat, pZFormat);
+}
+
+void ChartWidget::getAxesLimits(float* pXmin, float* pXmax,
+    float* pYmin, float* pYmax,
+    float* pZmin, float* pZmax)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    m_chart->getAxesLimits(pXmin, pXmax, pYmin, pYmax, pZmin, pZmax);
+}
+
+void ChartWidget::setLegendPosition(const float pX, const float pY)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    m_chart->setLegendPosition(pX, pY);
+}
+
+void ChartWidget::add(const Image& pImage)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+    
+    m_chart->add(pImage);
+}
+
+void ChartWidget::add(const Histogram& pHistogram)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    m_chart->add(pHistogram);
+}
+
+void ChartWidget::add(const Plot& pPlot)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    m_chart->add(pPlot);
+}
+
+void ChartWidget::add(const Surface& pSurface)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    m_chart->add(pSurface);
+}
+
+void ChartWidget::add(const VectorField& pVectorField)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    m_chart->add(pVectorField);
+}
+
+void ChartWidget::remove(const Image& pImage)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    m_chart->remove(pImage);
+}
+
+void ChartWidget::remove(const Histogram& pHistogram)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    m_chart->remove(pHistogram);
+}
+
+void ChartWidget::remove(const Plot& pPlot)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    m_chart->remove(pPlot);
+}
+
+void ChartWidget::remove(const Surface& pSurface)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    m_chart->remove(pSurface);
+}
+
+void ChartWidget::remove(const VectorField& pVectorField)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    m_chart->remove(pVectorField);
+}
+
+Image ChartWidget::image(const unsigned pWidth, const unsigned pHeight,
+    const ChannelFormat pFormat, const dtype pDataType)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    return m_chart->image(pWidth, pHeight, pFormat, pDataType);
+}
+
+Histogram ChartWidget::histogram(const unsigned pNBins, const dtype pDataType)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    return m_chart->histogram(pNBins, pDataType);
+}
+
+Plot ChartWidget::plot(const unsigned pNumPoints, const dtype pDataType,
+    const PlotType pPlotType, const MarkerType pMarkerType)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    return m_chart->plot(pNumPoints, pDataType, pPlotType, pMarkerType);
+}
+
+Surface ChartWidget::surface(const unsigned pNumXPoints, const unsigned pNumYPoints, const dtype pDataType,
+    const PlotType pPlotType, const MarkerType pMarkerType)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    return m_chart->surface(pNumXPoints, pNumYPoints, pDataType, pPlotType, pMarkerType);
+}
+
+VectorField ChartWidget::vectorField(const unsigned pNumPoints, const dtype pDataType)
+{
+    if(!m_init)
+        FG_ERROR("Chart has not been initialized, if using threads you must call initialize or draw from thread before using", FG_ERR_INTERNAL);
+
+    return m_chart->vectorField(pNumPoints, pDataType);
+}
+
+void ChartWidget::update()
+{
+    m_waitEvent.notify_all();
+}
+
+bool ChartWidget::waitEvent(unsigned int timeout)
+{
+    std::unique_lock<std::mutex> lock(m_mutex);
+
+    if(m_waitEvent.wait_for(lock, timeout*1ms)==std::cv_status::timeout)
+        return false;
+    return true;
+}
+
+void ChartWidget::glInit()
+{
+}
+
+void ChartWidget::glDraw()
+{
+    update();
+}
+
+void ChartWidget::initializeGL()
+{
+}
+
+void ChartWidget::resizeGL(int width, int height)
+{
+}
+
+void ChartWidget::paintGL()
+{
+}
+
+void ChartWidget::resizeEvent(QResizeEvent *evt)
+{
+    m_resize=true;
+    update();
+}
+
+void ChartWidget::closeEvent(QCloseEvent *evt)
+{
+    update();
+    QGLWidget::closeEvent(evt);
+}
+
+bool ChartWidget::event(QEvent *e)
+{
+    QEvent::Type type=e->type();
+
+    if(e->type() == QEvent::Show)
+        update();
+    else if(e->type() == QEvent::ParentChange) //The glContext will be changed, need to reinit openGl
+    {
+        bool ret=QGLWidget::event(e);
+        
+        return ret;
+    }
+    else if(e->type() == QEvent::Resize)
+    {
+        return QGLWidget::event(e);
+    }
+    return QGLWidget::event(e);
+}
+
+void ChartWidget::setThreadContext(QGLContext *glContext)
+{
+    if(!m_threaded)
+        FG_ERROR("Chart is not setup for threading, this function should not be called", FG_ERR_INTERNAL);
+
+    setContext(glContext, nullptr, false);
+    initialize();
+}
+
+void ChartWidget::initialize()
+{
+    m_resize=true;
+    setAutoBufferSwap(false);
+
+    glbinding::Binding::useCurrentContext();
+    glbinding::Binding::initialize();
+
+    m_chart=std::unique_ptr<forge::Chart>(new forge::Chart(m_chartType));
+
+    m_init=true;
+}
+
+void ChartWidget::terminate()
+{
+    m_chart.reset(nullptr);
+    m_init=false;
+}
+
+
+void ChartWidget::resize()
+{
+    m_resize=false;
+}
+
+
+void ChartWidget::render()
+{
+    if(!isVisible())
+        return;
+
+    if(!windowHandle()->isExposed())
+        return;
+
+    if(!m_init)
+        initialize();
+
+    if(m_resize)
+        resize();
+
+    glViewport(0, 0, width(), height());
+
+    // clear color and depth buffers
+    glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);
+
+    //draw
+    getChart(m_chart->get())->render(m_windowsId, 0, 0, width(), height(), IDENTITY, IDENTITY);
+
+    swapBuffers();
+}
+
+void ChartWidget::mousePressEvent(QMouseEvent* event)
+{
+    Qt::MouseButton button=event->button();
+
+    if(Qt::LeftButton == button)
+        m_leftClick=event->globalPos();
+    if(Qt::RightButton == button)
+        m_rightClick=event->globalPos();
+}
+
+void ChartWidget::mouseReleaseEvent(QMouseEvent* event)
+{
+    this->setCursor(QCursor(Qt::OpenHandCursor));
+}
+
+void ChartWidget::mouseMoveEvent(QMouseEvent* event)
+{
+    Qt::MouseButtons buttons=event->buttons();
+
+    if(Qt::LeftButton&buttons)
+    {
+        bool rightButton=Qt::RightButton&buttons;
+
+        if(!rightButton)
+        {
+            Qt::KeyboardModifiers keys=event->modifiers();
+
+            if(Qt::AltModifier&keys)
+            {
+            }
+            else
+            {
+            }
+        }
+        m_leftClick = event->globalPos();
+    }
+}
+
+}//namespace forge

--- a/src/api/cpp/image.cpp
+++ b/src/api/cpp/image.cpp
@@ -98,12 +98,19 @@ unsigned Image::size() const
     return retVal;
 }
 
+#ifdef FG_WINDOW_TOOLKIT
 void Image::render(const Window& pWindow,
                    const int pX, const int pY, const int pVPW, const int pVPH) const
 {
     FG_THROW(fg_render_image(pWindow.get(), get(), pX, pY, pVPW, pVPH));
 }
+#endif //FG_WINDOW_TOOLKIT
 
+void Image::render(const int windowId,
+    const int pX, const int pY, const int pVPW, const int pVPH) const
+{
+    FG_THROW(fg_render_image_to_id(windowId, get(), pX, pY, pVPW, pVPH));
+}
 
 fg_image Image::get() const
 {

--- a/src/api/cpp/window.cpp
+++ b/src/api/cpp/window.cpp
@@ -7,6 +7,8 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#ifdef FG_WINDOW_TOOLKIT
+
 #include <fg/window.h>
 
 #include <error.hpp>
@@ -154,3 +156,5 @@ void Window::saveFrameBuffer(const char* pFullPath)
 }
 
 }
+
+#endif //FG_WINDOW_TOOLKIT

--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -45,9 +45,6 @@ if(USE_FREEIMAGE)
 	ADD_DEFINITIONS(-DUSE_FREEIMAGE)
 endif()
 
-SET(USE_WINDOW_TOOLKIT "glfw3" CACHE STRING "Choose Window toolkit")
-SET_PROPERTY(CACHE USE_WINDOW_TOOLKIT PROPERTY STRINGS "glfw3" "sdl2")
-
 IF(${USE_WINDOW_TOOLKIT} STREQUAL "glfw3")
     #FIXME LATER: glfw3Config.cmake file provided by glfw 3.*
     # is found on different locations in different linux/unix

--- a/src/backend/chart.hpp
+++ b/src/backend/chart.hpp
@@ -85,6 +85,10 @@ class Chart {
             mChart->addRenderable(pRenderable);
         }
 
+        inline void removeRenderable(const std::shared_ptr<detail::AbstractRenderable> pRenderable) {
+            mChart->removeRenderable(pRenderable);
+        }
+
         inline void render(const int pWindowId,
                            const int pX, const int pY, const int pVPW, const int pVPH,
                            const glm::mat4 &pView, const glm::mat4 &pOrient) const {

--- a/src/backend/handle.cpp
+++ b/src/backend/handle.cpp
@@ -11,10 +11,12 @@
 
 using namespace forge;
 
+#ifdef FG_WINDOW_TOOLKIT
 fg_window getHandle(common::Window* pValue)
 {
     return reinterpret_cast<fg_window>(pValue);
 }
+#endif //FG_WINDOW_TOOLKIT
 
 fg_font getHandle(common::Font* pValue)
 {
@@ -51,10 +53,12 @@ fg_vector_field getHandle(common::VectorField* pValue)
     return reinterpret_cast<fg_vector_field>(pValue);
 }
 
+#ifdef FG_WINDOW_TOOLKIT
 common::Window* getWindow(const fg_window& pValue)
 {
     return reinterpret_cast<common::Window*>(pValue);
 }
+#endif //FG_WINDOW_TOOLKIT
 
 common::Font* getFont(const fg_font& pValue)
 {

--- a/src/backend/handle.hpp
+++ b/src/backend/handle.hpp
@@ -17,7 +17,9 @@
 #include <chart.hpp>
 #include <chart_renderables.hpp>
 
+#ifdef FG_WINDOW_TOOLKIT
 fg_window getHandle(forge::common::Window* pValue);
+#endif //FG_WINDOW_TOOLKIT
 
 fg_font getHandle(forge::common::Font* pValue);
 
@@ -33,7 +35,9 @@ fg_surface getHandle(forge::common::Surface* pValue);
 
 fg_vector_field getHandle(forge::common::VectorField* pValue);
 
+#ifdef FG_WINDOW_TOOLKIT
 forge::common::Window* getWindow(const fg_window& pValue);
+#endif //FG_WINDOW_TOOLKIT
 
 forge::common::Font* getFont(const fg_font& pValue);
 

--- a/src/backend/opengl/CMakeLists.txt
+++ b/src/backend/opengl/CMakeLists.txt
@@ -63,6 +63,14 @@ FILE(GLOB gl_sources
     "*.cpp"
     )
 
+if(NOT USE_QT5_WIDGET) #remove qChartWidget source
+    list(REMOVE_ITEM api_headers ${CMAKE_SOURCE_DIR}/include/fg/qChartWidget.h)
+    list(REMOVE_ITEM cpp_api_sources ${CMAKE_SOURCE_DIR}/src/api/cpp/qChartWidget.cpp)
+endif()
+
+message(STATUS "api headers: ${api_headers}")
+message(STATUS "cpp api sources: ${cpp_api_sources}")
+
 LIST(SORT c_api_headers)
 LIST(SORT c_api_sources)
 LIST(SORT cpp_api_headers)
@@ -114,6 +122,8 @@ ADD_LIBRARY(forge SHARED
     ${gl_sources}
     ${wtk_headers}
     ${wtk_sources}
+    ${qt5_widget_headers}
+    ${qt5_widget_sources}
     )
 
 TARGET_LINK_LIBRARIES(forge
@@ -135,7 +145,7 @@ IF(USE_SYSTEM_GLBINDING)
     TARGET_LINK_LIBRARIES(forge PRIVATE glbinding::glbinding)
 ELSE(USE_SYSTEM_GLBINDING)
     INCLUDE_DIRECTORIES(${GLBINDING_INCLUDE_DIRS})
-    TARGET_LINK_LIBRARIES(forge PRIVATE ${GLBINDING_LIBRARIES})
+    TARGET_LINK_LIBRARIES(forge PRIVATE glbinding)
     ADD_DEPENDENCIES(forge glbinding)
 ENDIF(USE_SYSTEM_GLBINDING)
 

--- a/src/backend/opengl/chart_impl.cpp
+++ b/src/backend/opengl/chart_impl.cpp
@@ -246,6 +246,16 @@ void AbstractChart::addRenderable(const std::shared_ptr<AbstractRenderable> pRen
     mRenderables.emplace_back(pRenderable);
 }
 
+void AbstractChart::removeRenderable(const std::shared_ptr<AbstractRenderable> pRenderable)
+{
+    auto pos=std::find(mRenderables.begin(), mRenderables.end(), pRenderable);
+
+    if(pos==mRenderables.end())
+        return;
+
+    mRenderables.erase(pos);
+}
+
 /********************* END-AbstractChart *********************/
 
 

--- a/src/backend/opengl/chart_impl.hpp
+++ b/src/backend/opengl/chart_impl.hpp
@@ -147,6 +147,7 @@ class AbstractChart : public AbstractRenderable {
         float zmin() const;
 
         void addRenderable(const std::shared_ptr<AbstractRenderable> pRenderable);
+        void removeRenderable(const std::shared_ptr<AbstractRenderable> pRenderable);
 };
 
 class chart2d_impl : public AbstractChart {

--- a/src/backend/opengl/chart_impl.hpp
+++ b/src/backend/opengl/chart_impl.hpp
@@ -24,6 +24,9 @@ namespace opengl
 
 class AbstractChart : public AbstractRenderable {
     protected:
+        /* force font_impl to hang around while chart exist*/
+        std::shared_ptr<forge::opengl::font_impl> mFonter;
+
         /* internal class attributes for
         * drawing ticks on axes for plots*/
         std::vector<float> mTickTextX;

--- a/src/backend/opengl/common.cpp
+++ b/src/backend/opengl/common.cpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <map>
 
 using namespace gl;
 using namespace forge;

--- a/src/backend/opengl/window_impl.cpp
+++ b/src/backend/opengl/window_impl.cpp
@@ -84,6 +84,7 @@ int getNextUniqueId()
 static std::mutex initMutex;
 static int initCallCount = -1;
 
+#ifdef FG_WINDOW_TOOLKIT
 void initWtkIfNotDone()
 {
     std::lock_guard<std::mutex> lock(initMutex);
@@ -418,4 +419,7 @@ void window_impl::saveFrameBuffer(const char* pFullPath)
 }
 
 }
+
+#endif //FG_WINDOW_TOOLKIT
+
 }

--- a/src/backend/opengl/window_impl.hpp
+++ b/src/backend/opengl/window_impl.hpp
@@ -11,6 +11,8 @@
 
 #include <common.hpp>
 
+#ifdef FG_WINDOW_TOOLKIT
+
 #if defined(USE_GLFW)
 #include <glfw/window.hpp>
 #elif defined(USE_SDL)
@@ -81,3 +83,5 @@ void MakeContextCurrent(const window_impl* pWindow);
 
 }
 }
+
+#endif //FG_WINDOW_TOOLKIT

--- a/src/backend/window.hpp
+++ b/src/backend/window.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#ifdef FG_WINDOW_TOOLKIT
+
 #include <backend.hpp>
 #include <window_impl.hpp>
 
@@ -139,3 +141,5 @@ class Window {
 
 }
 }
+
+#endif //FG_WINDOW_TOOLKIT


### PR DESCRIPTION
This adds a qt5 widget ChartWidget (and example) to the API that can be enabled by adding USE_QT5_WIDGET=ON to the cmake build. Also added the ability to set the USE_WINDOW_TOOLKIT to "none" removing window creation support.

This is not quite ready needs clean up and testing across platforms, put it here for the moment to get feedback.