### PR TITLE
Add support for Hunter package manager (optional: default off)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,17 @@
 cmake_minimum_required(VERSION 3.5)
 
+OPTION(USE_HUNTER "Use Hunter cmake package handler" OFF)
+if(USE_HUNTER)
+    include(${CMAKE_CURRENT_LIST_DIR}/CMakeModules/HunterGate.cmake)
+    
+    HunterGate(
+        URL "https://github.com/ruslo/hunter/archive/v0.19.208.tar.gz"
+        SHA1 "4128ac8c79c21b250bf825e8119ce0bff05e5132"
+    )
+endif()
+
 project(Forge VERSION 1.1.0 LANGUAGES C CXX)
+
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
@@ -14,14 +25,27 @@ include(DependencyCheck)
 include(Version)
 include(FGInstallDirs)
 
+if(USE_HUNTER)
+    hunter_add_package(glbinding)
+    hunter_add_package(glm)
+    hunter_add_package(freetype)
+    hunter_add_package(Boost)
+
+    find_package(freetype CONFIG REQUIRED)
+else()
+    find_package(freetype REQUIRED)
+endif()
+
 find_package(Doxygen QUIET)
 find_package(glbinding REQUIRED)
 find_package(glm REQUIRED)
-find_package(FreeType)
-find_package(FontConfig QUIET)
+
+if(UNIX)
+    find_package(FontConfig REQUIRED)
+endif()
 find_package(X11 QUIET)
 find_package(FreeImage QUIET)
-find_package(Boost)
+find_package(Boost REQUIRED)
 
 option(BUILD_DOCS      "Build Documentation"               ${DOXYGEN_FOUND})
 option(BUILD_EXAMPLES  "Build Examples"                    ON)

--- a/CMakeModules/Findfreetype.cmake
+++ b/CMakeModules/Findfreetype.cmake
@@ -15,19 +15,18 @@
 # Usage:
 # find_package(FreeType)
 # if (FreeType_FOUND)
-#    target_link_libraries(mylib PRIVATE FreeType::FreeType)
+#    target_link_libraries(mylib PRIVATE freetype::freetype)
 # endif (FreeType_FOUND)
 #
 # OR if you want to link against the static library:
 #
 # find_package(FreeType)
 # if (FreeType_FOUND)
-#    target_link_libraries(mylib PRIVATE FreeType::FreeType_STATIC)
+#    target_link_libraries(mylib PRIVATE freetype::freetype_STATIC)
 # endif (FreeType_FOUND)
 #
 # NOTE: You do not need to include the Freetype include directories since they
 # will be included as part of the target_link_libraries command
-
 if(WIN32)
     include(build_freetype)
 else(WIN32)
@@ -46,9 +45,9 @@ else(WIN32)
         REQUIRED_VARS FreeType_LIBRARY FreeType_INCLUDE_DIR
         )
 
-    if (FreeType_FOUND AND NOT TARGET FreeType::FreeType)
-        add_library(FreeType::FreeType UNKNOWN IMPORTED)
-        set_target_properties(FreeType::FreeType PROPERTIES
+    if (FreeType_FOUND AND NOT TARGET freetype::freetype)
+        add_library(freetype::freetype UNKNOWN IMPORTED)
+        set_target_properties(freetype::freetype PROPERTIES
             IMPORTED_LINK_INTERFACE_LANGUAGE "C"
             IMPORTED_LOCATION "${FreeType_LIBRARY}"
             INTERFACE_INCLUDE_DIRECTORIES "${FreeType_INCLUDE_DIR}")

--- a/CMakeModules/build_freetype.cmake
+++ b/CMakeModules/build_freetype.cmake
@@ -1,3 +1,4 @@
+
 include(ExternalProject)
 
 set(LIB_POSTFIX "")
@@ -32,21 +33,21 @@ ExternalProject_Add(
 
 ExternalProject_Get_Property(ft-ext install_dir)
 
-set(FreeType_INCLUDE_DIR ${install_dir}/include/freetype2 CACHE INTERNAL "" FORCE)
-set(FreeType_LIBRARY ${freetype_location} CACHE INTERNAL "" FORCE)
+set(freetype_INCLUDE_DIR ${install_dir}/include/freetype2 CACHE INTERNAL "" FORCE)
+set(freetype_LIBRARY ${freetype_location} CACHE INTERNAL "" FORCE)
 
-mark_as_advanced(FreeType_INCLUDE_DIR FreeType_LIBRARY)
+mark_as_advanced(freetype_INCLUDE_DIR freetype_LIBRARY)
 
 include(FindPackageHandleStandardArgs)
 
-find_package_handle_standard_args(FreeType REQUIRED_VARS FreeType_LIBRARY FreeType_INCLUDE_DIR)
-
-if (FreeType_FOUND AND NOT TARGET FreeType::FreeType)
-    file(MAKE_DIRECTORY ${FreeType_INCLUDE_DIR})
-    add_library(FreeType::FreeType STATIC IMPORTED)
-    set_target_properties(FreeType::FreeType PROPERTIES
+find_package_handle_standard_args(freetype REQUIRED_VARS freetype_LIBRARY freetype_INCLUDE_DIR)
+    
+if (freetype_FOUND AND NOT TARGET freetype::freetype)
+    file(MAKE_DIRECTORY ${freetype_INCLUDE_DIR})
+    add_library(freetype::freetype STATIC IMPORTED)
+    set_target_properties(freetype::freetype PROPERTIES
         IMPORTED_LINK_INTERFACE_LANGUAGE "C"
-        IMPORTED_LOCATION "${FreeType_LIBRARY}"
-        INTERFACE_INCLUDE_DIRECTORIES "${FreeType_INCLUDE_DIR}")
-    add_dependencies(FreeType::FreeType ft-ext)
+        IMPORTED_LOCATION "${freetype_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${freetype_INCLUDE_DIR}")
+    add_dependencies(freetype::freetype ft-ext)
 endif ()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,6 +6,10 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
+if(USE_HUNTER)
+    hunter_add_package(OpenCL)
+endif()
+
 find_package(OpenGL REQUIRED)
 find_package(CUDA QUIET)
 find_package(OpenCL 1.2 QUIET)

--- a/src/backend/opengl/CMakeLists.txt
+++ b/src/backend/opengl/CMakeLists.txt
@@ -81,7 +81,7 @@ target_link_libraries(${BackendTarget}
     PRIVATE
         glbinding::glbinding
         glm
-        FreeType::FreeType
+        freetype::freetype
         Boost::boost
         backend_interface
         wtk_interface

--- a/src/backend/opengl/glfw/CMakeLists.txt
+++ b/src/backend/opengl/glfw/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(USE_HUNTER)
+    hunter_add_package(glfw)
+endif()
+
 find_package(glfw3)
 
 add_library(wtk_interface INTERFACE)

--- a/src/backend/opengl/sdl/CMakeLists.txt
+++ b/src/backend/opengl/sdl/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(USE_HUNTER)
+    hunter_add_package(SDL2)
+endif()
+
 find_package(SDL2)
 
 add_library(wtk_interface INTERFACE)


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, documentation update, new examples etc.)**
Support for new packaging framework

**What is the current behavior? (You can also link to an open issue here)**
Adds support for Hunter package manager

**What is the new behavior (if this is a feature change)?**
If cmake is given -DUSE_HUNTER=ON then hunter will fetch the require 3rd party libraries and compile them. By default, HUNTER usage is turned off.
  