### PR TITLE
fix: move stranded definitions into appropriate namespaces

### DIFF
--- a/src/api/c/chart.cpp
+++ b/src/api/c/chart.cpp
@@ -24,6 +24,7 @@
 #include <window.hpp>
 
 using namespace forge;
+using namespace forge::common;
 
 fg_err fg_create_chart(fg_chart *pChart,
                        const fg_chart_type pChartType)

--- a/src/api/c/exception.cpp
+++ b/src/api/c/exception.cpp
@@ -40,8 +40,8 @@ const char * fg_err_to_string(const fg_err err)
 
 void fg_get_last_error(char **msg, int *len)
 {
-    std::string &error = getGlobalErrorString();
-    int slen = std::min(MAX_ERR_SIZE, (int)error.size());
+    std::string &error = forge::common::getGlobalErrorString();
+    int slen = std::min(forge::common::MAX_ERR_SIZE, (int)error.size());
     if(len && slen == 0) {
         *len = 0;
         *msg = NULL;

--- a/src/api/c/font.cpp
+++ b/src/api/c/font.cpp
@@ -14,6 +14,8 @@
 
 using namespace forge;
 
+using forge::common::getFont;
+
 fg_err fg_create_font(fg_font* pFont)
 {
     try {

--- a/src/api/c/histogram.cpp
+++ b/src/api/c/histogram.cpp
@@ -14,6 +14,8 @@
 
 using namespace forge;
 
+using forge::common::getHistogram;
+
 fg_err fg_create_histogram(fg_histogram *pHistogram,
         const unsigned pNBins, const fg_dtype pType)
 {

--- a/src/api/c/image.cpp
+++ b/src/api/c/image.cpp
@@ -17,6 +17,9 @@
 
 using namespace forge;
 
+using forge::common::getImage;
+using forge::common::getWindow;
+
 fg_err fg_create_image(fg_image* pImage,
                        const unsigned pWidth, const unsigned pHeight,
                        const fg_channel_format pFormat, const fg_dtype pType)

--- a/src/api/c/plot.cpp
+++ b/src/api/c/plot.cpp
@@ -14,6 +14,8 @@
 
 using namespace forge;
 
+using forge::common::getPlot;
+
 fg_err fg_create_plot(fg_plot *pPlot,
                       const unsigned pNPoints, const fg_dtype pType,
                       const fg_chart_type pChartType,

--- a/src/api/c/surface.cpp
+++ b/src/api/c/surface.cpp
@@ -14,6 +14,8 @@
 
 using namespace forge;
 
+using forge::common::getSurface;
+
 fg_err fg_create_surface(fg_surface *pSurface,
                       const unsigned pXPoints, const unsigned pYPoints,
                       const fg_dtype pType,

--- a/src/api/c/vector_field.cpp
+++ b/src/api/c/vector_field.cpp
@@ -14,6 +14,8 @@
 
 using namespace forge;
 
+using forge::common::getVectorField;
+
 fg_err fg_create_vector_field(fg_vector_field *pField,
                               const unsigned pNPoints,
                               const fg_dtype pType,

--- a/src/api/c/window.cpp
+++ b/src/api/c/window.cpp
@@ -15,6 +15,11 @@
 
 using namespace forge;
 
+using forge::common::getWindow;
+using forge::common::getFont;
+using forge::common::getImage;
+using forge::common::getChart;
+
 fg_err fg_create_window(fg_window *pWindow,
                         const int pWidth, const int pHeight,
                         const char* pTitle,

--- a/src/api/cpp/exception.cpp
+++ b/src/api/cpp/exception.cpp
@@ -19,17 +19,17 @@ using std::string;
 using std::stringstream;
 using std::cerr;
 
+namespace forge
+{
+
 void stringcopy(char* dest, const char* src, size_t len)
 {
 #if defined(OS_WIN)
-    strncpy_s(dest, MAX_ERR_SIZE, src, len);
+    strncpy_s(dest, forge::common::MAX_ERR_SIZE, src, len);
 #else
     strncpy(dest, src, len);
 #endif
 }
-
-namespace forge
-{
 
 Error::Error() : mErrCode(FG_ERR_UNKNOWN)
 {

--- a/src/backend/common/cmap.hpp
+++ b/src/backend/common/cmap.hpp
@@ -9,6 +9,11 @@
 
 #pragma once
 
+namespace forge
+{
+namespace common
+{
+
 /**
  * Color maps: heat, rainbow are pulled from the following resource:
  *
@@ -2928,3 +2933,6 @@ float cmap_viridis[] =
     0.983868f, 0.904867f, 0.136897f, 1.0f,
     0.993248f, 0.906157f, 0.143936f, 1.0f,
 };
+
+}
+}

--- a/src/backend/common/defines.hpp
+++ b/src/backend/common/defines.hpp
@@ -11,8 +11,13 @@
 
 #include <string>
 
+namespace forge
+{
+namespace common
+{
+
 inline std::string
-clipFilePath(std::string path, std::string str)
+clipPath(std::string path, std::string str)
 {
     try {
         std::string::size_type pos = path.rfind(str);
@@ -32,11 +37,14 @@ clipFilePath(std::string path, std::string str)
         #define snprintf sprintf_s
     #endif
     #define STATIC_ static
-    #define __FG_FILENAME__ (clipFilePath(__FILE__, "src\\").c_str())
+    #define __FG_FILENAME__ (forge::common::clipPath(__FILE__, "src\\").c_str())
 #else
     //#ifndef __PRETTY_FUNCTION__
     //    #define __PRETTY_FUNCTION__ __func__ // __PRETTY_FUNCTION__ Fallback
     //#endif
     #define STATIC_ inline
-    #define __FG_FILENAME__ (clipFilePath(__FILE__, "src/").c_str())
+    #define __FG_FILENAME__ (forge::common::clipPath(__FILE__, "src/").c_str())
 #endif
+
+}
+}

--- a/src/backend/common/err_common.cpp
+++ b/src/backend/common/err_common.cpp
@@ -17,8 +17,10 @@
 #include <cstdio>
 #include <cstdlib>
 
-using namespace forge;
-
+namespace forge
+{
+namespace common
+{
 using std::string;
 using std::stringstream;
 
@@ -136,4 +138,7 @@ const char * getName(forge::dtype type)
         case u16    :   return "unsigned short";
         default     :   TYPE_ERROR(1, type);
     }
+}
+
+}
 }

--- a/src/backend/common/err_common.hpp
+++ b/src/backend/common/err_common.hpp
@@ -17,6 +17,10 @@
 #include <cassert>
 #include <vector>
 
+namespace forge
+{
+namespace common
+{
 ////////////////////////////////////////////////////////////////////////////////
 // Exception Classes
 // Error, TypeError, ArgumentError
@@ -138,23 +142,23 @@ const char * getName(forge::dtype type);
 ////////////////////////////////////////////////////////////////////////////////
 // Macros
 ////////////////////////////////////////////////////////////////////////////////
-#define ARG_ASSERT(INDEX, COND) do {                        \
-        if((COND) == false) {                               \
-            throw ArgumentError(__PRETTY_FUNCTION__,        \
-                                __FG_FILENAME__, __LINE__,  \
-                                INDEX, #COND);              \
-        }                                                   \
+#define ARG_ASSERT(INDEX, COND) do {                                \
+        if((COND) == false) {                                       \
+            throw forge::common::ArgumentError(__PRETTY_FUNCTION__, \
+                                __FG_FILENAME__, __LINE__,          \
+                                INDEX, #COND);                      \
+        }                                                           \
     } while(0)
 
 #define TYPE_ERROR(INDEX, type) do {                        \
-        throw TypeError(__PRETTY_FUNCTION__,                \
+        throw forge::common::TypeError(__PRETTY_FUNCTION__, \
                         __FG_FILENAME__, __LINE__,          \
                         INDEX, type);                       \
     } while(0)                                              \
 
 
 #define FG_ERROR(MSG, ERR_TYPE) do {                        \
-        throw FgError(__PRETTY_FUNCTION__,                  \
+        throw forge::common::FgError(__PRETTY_FUNCTION__,   \
                       __FG_FILENAME__, __LINE__,            \
                       MSG, ERR_TYPE);                       \
     } while(0)
@@ -168,5 +172,8 @@ const char * getName(forge::dtype type);
 
 #define CATCHALL                                            \
     catch(...) {                                            \
-        return processException();                          \
+        return forge::common::processException();           \
     }
+
+}
+}

--- a/src/backend/common/handle.cpp
+++ b/src/backend/common/handle.cpp
@@ -9,84 +9,90 @@
 
 #include <handle.hpp>
 
-using namespace forge;
+namespace forge
+{
+namespace common
+{
 
-fg_window getHandle(common::Window* pValue)
+fg_window getHandle(Window* pValue)
 {
     return reinterpret_cast<fg_window>(pValue);
 }
 
-fg_font getHandle(common::Font* pValue)
+fg_font getHandle(Font* pValue)
 {
     return reinterpret_cast<fg_font>(pValue);
 }
 
-fg_image getHandle(common::Image* pValue)
+fg_image getHandle(Image* pValue)
 {
     return reinterpret_cast<fg_image>(pValue);
 }
 
-fg_chart getHandle(common::Chart* pValue)
+fg_chart getHandle(Chart* pValue)
 {
     return reinterpret_cast<fg_chart>(pValue);
 }
 
-fg_histogram getHandle(common::Histogram* pValue)
+fg_histogram getHandle(Histogram* pValue)
 {
     return reinterpret_cast<fg_histogram>(pValue);
 }
 
-fg_plot getHandle(common::Plot* pValue)
+fg_plot getHandle(Plot* pValue)
 {
     return reinterpret_cast<fg_plot>(pValue);
 }
 
-fg_surface getHandle(common::Surface* pValue)
+fg_surface getHandle(Surface* pValue)
 {
     return reinterpret_cast<fg_surface>(pValue);
 }
 
-fg_vector_field getHandle(common::VectorField* pValue)
+fg_vector_field getHandle(VectorField* pValue)
 {
     return reinterpret_cast<fg_vector_field>(pValue);
 }
 
-common::Window* getWindow(const fg_window& pValue)
+Window* getWindow(const fg_window& pValue)
 {
     return reinterpret_cast<common::Window*>(pValue);
 }
 
-common::Font* getFont(const fg_font& pValue)
+Font* getFont(const fg_font& pValue)
 {
     return reinterpret_cast<common::Font*>(pValue);
 }
 
-common::Image* getImage(const fg_image& pValue)
+Image* getImage(const fg_image& pValue)
 {
     return reinterpret_cast<common::Image*>(pValue);
 }
 
-common::Chart* getChart(const fg_chart& pValue)
+Chart* getChart(const fg_chart& pValue)
 {
     return reinterpret_cast<common::Chart*>(pValue);
 }
 
-common::Histogram* getHistogram(const fg_histogram& pValue)
+Histogram* getHistogram(const fg_histogram& pValue)
 {
     return reinterpret_cast<common::Histogram*>(pValue);
 }
 
-common::Plot* getPlot(const fg_plot& pValue)
+Plot* getPlot(const fg_plot& pValue)
 {
     return reinterpret_cast<common::Plot*>(pValue);
 }
 
-common::Surface* getSurface(const fg_surface& pValue)
+Surface* getSurface(const fg_surface& pValue)
 {
     return reinterpret_cast<common::Surface*>(pValue);
 }
 
-common::VectorField* getVectorField(const fg_vector_field& pValue)
+VectorField* getVectorField(const fg_vector_field& pValue)
 {
     return reinterpret_cast<common::VectorField*>(pValue);
+}
+
+}
 }

--- a/src/backend/common/handle.hpp
+++ b/src/backend/common/handle.hpp
@@ -17,34 +17,42 @@
 #include <chart.hpp>
 #include <chart_renderables.hpp>
 
-fg_window getHandle(forge::common::Window* pValue);
+namespace forge
+{
+namespace common
+{
 
-fg_font getHandle(forge::common::Font* pValue);
+fg_window getHandle(Window* pValue);
 
-fg_image getHandle(forge::common::Image* pValue);
+fg_font getHandle(Font* pValue);
 
-fg_chart getHandle(forge::common::Chart* pValue);
+fg_image getHandle(Image* pValue);
 
-fg_histogram getHandle(forge::common::Histogram* pValue);
+fg_chart getHandle(Chart* pValue);
 
-fg_plot getHandle(forge::common::Plot* pValue);
+fg_histogram getHandle(Histogram* pValue);
 
-fg_surface getHandle(forge::common::Surface* pValue);
+fg_plot getHandle(Plot* pValue);
 
-fg_vector_field getHandle(forge::common::VectorField* pValue);
+fg_surface getHandle(Surface* pValue);
 
-forge::common::Window* getWindow(const fg_window& pValue);
+fg_vector_field getHandle(VectorField* pValue);
 
-forge::common::Font* getFont(const fg_font& pValue);
+Window* getWindow(const fg_window& pValue);
 
-forge::common::Image* getImage(const fg_image& pValue);
+Font* getFont(const fg_font& pValue);
 
-forge::common::Chart* getChart(const fg_chart& pValue);
+Image* getImage(const fg_image& pValue);
 
-forge::common::Histogram* getHistogram(const fg_histogram& pValue);
+Chart* getChart(const fg_chart& pValue);
 
-forge::common::Plot* getPlot(const fg_plot& pValue);
+Histogram* getHistogram(const fg_histogram& pValue);
 
-forge::common::Surface* getSurface(const fg_surface& pValue);
+Plot* getPlot(const fg_plot& pValue);
 
-forge::common::VectorField* getVectorField(const fg_vector_field& pValue);
+Surface* getSurface(const fg_surface& pValue);
+
+VectorField* getVectorField(const fg_vector_field& pValue);
+
+}
+}

--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -15,6 +15,11 @@
 #include <Windows.h>
 #endif
 
+namespace forge
+{
+namespace common
+{
+
 using std::string;
 
 string getEnvVar(const std::string &key)
@@ -34,4 +39,7 @@ string getEnvVar(const std::string &key)
     char * str = getenv(key.c_str());
     return str==NULL ? string("") : string(str);
 #endif
+}
+
+}
 }

--- a/src/backend/common/util.hpp
+++ b/src/backend/common/util.hpp
@@ -13,4 +13,12 @@
 
 #pragma once
 
+namespace forge
+{
+namespace common
+{
+
 std::string getEnvVar(const std::string &key);
+
+}
+}

--- a/src/backend/opengl/chart_impl.cpp
+++ b/src/backend/opengl/chart_impl.cpp
@@ -35,6 +35,11 @@
 using namespace gl;
 using namespace std;
 
+namespace forge
+{
+namespace opengl
+{
+
 typedef std::vector<std::string>::const_iterator StringIter;
 
 static const int CHART2D_FONT_SIZE = 12;
@@ -75,11 +80,6 @@ int calcTrgtFntSize(const float w, const float h)
 {
     return CHART2D_FONT_SIZE;
 }
-
-namespace forge
-{
-namespace opengl
-{
 
 /********************* BEGIN-AbstractChart *********************/
 

--- a/src/backend/opengl/colormap_impl.cpp
+++ b/src/backend/opengl/colormap_impl.cpp
@@ -26,6 +26,8 @@ colormap_impl::colormap_impl()
     mRedMapBuffer(0), mMoodMapBuffer(0), mHeatMapBuffer(0),
     mBlueMapBuffer(0)
 {
+    using namespace forge::common;
+
     size_t channel_bytes = sizeof(float)*4; /* 4 is for 4 channels */
     mDefMapLen     = (GLuint)(sizeof(cmap_default)  / channel_bytes);
     mSpecMapLen    = (GLuint)(sizeof(cmap_spectrum) / channel_bytes);

--- a/src/backend/opengl/err_opengl.cpp
+++ b/src/backend/opengl/err_opengl.cpp
@@ -17,6 +17,11 @@
 
 using namespace gl;
 
+namespace forge
+{
+namespace opengl
+{
+
 void commonErrorCheck(const char *pMsg, const char* pFile, int pLine)
 {
     GLenum x = glGetError();
@@ -40,4 +45,7 @@ void glErrorCheck(const char *pMsg, const char* pFile, int pLine)
 void glForceErrorCheck(const char *pMsg, const char* pFile, int pLine)
 {
     commonErrorCheck(pMsg, pFile, pLine);
+}
+
+}
 }

--- a/src/backend/opengl/err_opengl.hpp
+++ b/src/backend/opengl/err_opengl.hpp
@@ -11,8 +11,16 @@
 
 #include <fg/defines.h>
 
+namespace forge
+{
+namespace opengl
+{
+
 void glErrorCheck(const char *pMsg, const char* pFile, int pLine);
 void glForceErrorCheck(const char *pMsg, const char* pFile, int pLine);
 
 #define CheckGL(msg)      glErrorCheck     (msg, __FILE__, __LINE__)
 #define ForceCheckGL(msg) glForceErrorCheck(msg, __FILE__, __LINE__)
+
+}
+}

--- a/src/backend/opengl/font_atlas_impl.cpp
+++ b/src/backend/opengl/font_atlas_impl.cpp
@@ -60,12 +60,12 @@
 
 using namespace gl;
 
-static const int BORDER_GAP = 4;
-
 namespace forge
 {
 namespace opengl
 {
+
+static const int BORDER_GAP = 4;
 
 int FontAtlas::fit(const size_t pIndex, const size_t pWidth, const size_t pHeight)
 {

--- a/src/backend/opengl/font_impl.cpp
+++ b/src/backend/opengl/font_impl.cpp
@@ -63,6 +63,9 @@ namespace forge
 namespace opengl
 {
 
+const float MIN_FONT_SIZE = 8.0f;
+const float MAX_FONT_SIZE = 24.0f;
+
 #ifdef NDEBUG
 /* Relase Mode */
 #define FT_THROW_ERROR(msg, error) \

--- a/src/backend/opengl/font_impl.hpp
+++ b/src/backend/opengl/font_impl.hpp
@@ -16,9 +16,6 @@
 #include <vector>
 #include <memory>
 
-static const float MIN_FONT_SIZE = 8.0f;
-static const float MAX_FONT_SIZE = 24.0f;
-
 namespace forge
 {
 namespace opengl

--- a/src/backend/opengl/surface_impl.cpp
+++ b/src/backend/opengl/surface_impl.cpp
@@ -23,6 +23,12 @@
 using namespace gl;
 using namespace std;
 
+
+namespace forge
+{
+namespace opengl
+{
+
 void generateGridIndices(std::vector<unsigned int>& indices,
                          unsigned short rows, unsigned short cols)
 {
@@ -50,11 +56,6 @@ void generateGridIndices(std::vector<unsigned int>& indices,
         }
     }
 }
-
-namespace forge
-{
-namespace opengl
-{
 
 void surface_impl::bindResources(const int pWindowId)
 {

--- a/src/backend/opengl/update_buffer.cpp
+++ b/src/backend/opengl/update_buffer.cpp
@@ -22,7 +22,7 @@ fg_err fg_update_vertex_buffer(const unsigned pBufferId,
         glBufferSubData(GL_ARRAY_BUFFER, 0, pBufferSize, pBufferData);
         glBindBuffer(GL_ARRAY_BUFFER, 0);
     }
-    CATCHALL
+    CATCHALL;
 
     return FG_ERR_NONE;
 }
@@ -36,7 +36,7 @@ fg_err fg_update_pixel_buffer(const unsigned pBufferId,
         glBufferSubData(GL_PIXEL_UNPACK_BUFFER, 0, pBufferSize, pBufferData);
         glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
     }
-    CATCHALL
+    CATCHALL;
 
     return FG_ERR_NONE;
 }
@@ -46,7 +46,7 @@ fg_err fg_finish()
     try {
         glFinish();
     }
-    CATCHALL
+    CATCHALL;
 
     return FG_ERR_NONE;
 }

--- a/src/backend/opengl/vector_field_impl.cpp
+++ b/src/backend/opengl/vector_field_impl.cpp
@@ -20,9 +20,6 @@
 using namespace gl;
 using namespace std;
 
-// identity matrix
-static const glm::mat4 I(1.0f);
-
 namespace forge
 {
 namespace opengl

--- a/src/backend/opengl/window_impl.cpp
+++ b/src/backend/opengl/window_impl.cpp
@@ -21,6 +21,9 @@
 using namespace gl;
 using namespace forge;
 
+namespace forge
+{
+
 #ifdef USE_FREEIMAGE
 #include <FreeImage.h>
 
@@ -67,9 +70,6 @@ private:
     FIBITMAP * pBitmap;
 };
 #endif //USE_FREEIMAGE
-
-namespace forge
-{
 
 /* following function is thread safe */
 int getNextUniqueId()


### PR DESCRIPTION
This resolves naming conflicts when static library of forge is created for use with other applications.