### PR TITLE
Change hunter glfw package version to 3.3.0-p2

### DIFF
--- a/CMakeModules/Hunter/config.cmake
+++ b/CMakeModules/Hunter/config.cmake
@@ -59,7 +59,7 @@ myhunter_config(glbinding 2.1.3-p0
     OPTION_BUILD_TOOLS=ON
     gtest_force_shared_crt=ON)
 
-myhunter_config(glfw 3.3.0-p4
+myhunter_config(glfw 3.3.0-p2
     GLFW_BUILD_DOCS=OFF
     GLFW_BUILD_EXAMPLES=OFF
     GLFW_BUILD_TESTS=OFF)


### PR DESCRIPTION
The version prior to this change, 3.3.0-p4, increased minimum cmake
version to 3.8. To bring it down to 3.0, the version of glfw from hunter
had to be changed to 3.3.0-p2