### PR TITLE
Remove experimental glm/transform header

### DIFF
--- a/src/backend/opengl/font_impl.cpp
+++ b/src/backend/opengl/font_impl.cpp
@@ -20,7 +20,6 @@
 
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>
-#include <glm/gtx/transform.hpp>
 
 #include <ft2build.h>
 #include FT_FREETYPE_H


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, documentation update, new examples etc.)**
Buf fix

**What is the current behavior? (You can also link to an open issue here)**
Starting with glm-0.9.9, experimental headers can only
be included if GLM_ENABLE_EXPERIMENTAL is defined before
the inclusion of the header. Thus causing builds to fail if 0.9.9 version
is used.

**What is the new behavior (if this is a feature change)?**
No change in behavior, just fixes a build issue.