### PR TITLE
Add install path to win registry for cmake

### DIFF
--- a/CMakeModules/nsis/NSIS.definitions.nsh.in
+++ b/CMakeModules/nsis/NSIS.definitions.nsh.in
@@ -24,7 +24,7 @@ Forge uses OpenGL >=3.3 forward compatible contexts, so please make sure you hav
 ; Defines for Finish Page
 !define MUI_FINISHPAGE_RUN "explorer.exe"
 !define MUI_FINISHPAGE_RUN_PARAMETERS "$INSTDIR"
-!define MUI_FINISHPAGE_RUN_TEXT "Open Forge Install Directory to see Examples"
+!define MUI_FINISHPAGE_RUN_TEXT "Open Forge Install Directory"
 !define MUI_FINISHPAGE_SHOWREADME "http://arrayfire.org/forge/index.htm"
 !define MUI_FINISHPAGE_SHOWREADME_TEXT "Open Forge Documentation on the Web"
 !define MUI_FINISHPAGE_LINK "ArrayFire Support and Services"

--- a/CMakeModules/nsis/NSIS.template.in
+++ b/CMakeModules/nsis/NSIS.template.in
@@ -29,6 +29,8 @@
   ;Default installation folder
   InstallDir "@CPACK_NSIS_INSTALL_ROOT@\@CPACK_PACKAGE_INSTALL_DIRECTORY@\v@CPACK_PACKAGE_VERSION_MAJOR@"
 
+  !define cmake_pkg_reg_key 'HKCU "Software\Kitware\CMake\Packages\Forge"'
+
 ;--------------------------------
 ;General
 
@@ -695,7 +697,8 @@ Section "-Core installation"
 @CPACK_NSIS_CREATE_ICONS_EXTRA@
   CreateShortCut "$SMPROGRAMS\$STARTMENU_FOLDER\Uninstall.lnk" "$INSTDIR\Uninstall.exe"
 
-  CreateShortcut "$INSTDIR\..\cmake.lnk" "$INSTDIR\cmake"
+  ;Add key for CMake package
+  WriteRegStr ${cmake_pkg_reg_key} Forge_CMake_DIR '$INSTDIR'
 
   ;Read a value from an InstallOptions INI file
   !insertmacro MUI_INSTALLOPTIONS_READ $DO_NOT_ADD_TO_PATH "NSIS.InstallOptions.ini" "Field 2" "State"
@@ -852,7 +855,9 @@ Section "Uninstall"
 @CPACK_NSIS_DELETE_ICONS@
 @CPACK_NSIS_DELETE_ICONS_EXTRA@
 
-  Delete "$INSTDIR\..\cmake.lnk"
+  ;Delete cmake package key
+  DeleteRegValue ${cmake_pkg_reg_key} Forge_CMake_DIR
+
   ;Delete empty start menu parent diretories
   StrCpy $MUI_TEMP "$SMPROGRAMS\$MUI_TEMP"
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,16 @@ An OpenGL interop library that can be used with ArrayFire or any other applicati
 You can find the most recent and updated documentation [here](http://arrayfire.org/forge/index.htm).
 
 ### Dependencies
-[glbinding](https://github.com/cginternals/glbinding), [GLFW](http://www.glfw.org/), [freetype](http://www.freetype.org/) and [FreeImage](http://freeimage.sourceforge.net/) (optional).
 
-On `Linux` & `OS X`, [fontconfig](http://www.freedesktop.org/wiki/Software/fontconfig/) is required. [SDL2](https://www.libsdl.org/) can be used as an alternative to `glfw`.
+- [glbinding](https://github.com/cginternals/glbinding)
+- [GLFW](http://www.glfw.org/) or [SDL2](https://www.libsdl.org/)
+- [freetype](http://www.freetype.org/)
+- [boost](https://www.boost.org/) - not a runtime dependency.
+- [FreeImage](http://freeimage.sourceforge.net/) (optional).
+- [fontconfig](http://www.freedesktop.org/wiki/Software/fontconfig/) on Linux and OSX.
 
-Above dependencies are available through package managers on most of the Unix/Linux based distributions. On Windows, we recommend using [vcpkg](https://github.com/Microsoft/vcpkg) to quickly setup forge development environment.
+**Linux/Unix**: Dependencies should be available via respective package managers.
+**Windows**: We recommend [vcpkg](https://github.com/Microsoft/vcpkg).
 
 ### Sample Images
 |     |     |


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, documentation update, new examples etc.)**
Change NSIS template to write to windows registry for automatic pickup of ArrayFire by CMake find_package commands.

**What is the current behavior? (You can also link to an open issue here)**
CMake cannot find Forge automatically unless `Forge_DIR` variable is set.

**What is the new behavior (if this is a feature change)?**
CMake can find Forge automatically on Windows