### PR TITLE
Fix cl2.hpp header download cmake script

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -43,16 +43,14 @@ cmake_dependent_option(FG_BUILD_CUDA_EXAMPLES
   "Build cuda examples" ON
   "CUDA_FOUND;FG_BUILD_EXAMPLES" OFF)
 
-cmake_dependent_option(FG_USE_SYSTEM_CL2HPP
-  "Use system cl2.hpp header" OFF "OpenCL_FOUND" OFF)
-
-include_if_not(FG_USE_SYSTEM_CL2HPP build_cl2hpp)
-
-mark_as_advanced(FG_BUILD_CUDA_EXAMPLES FG_BUILD_OPENCL_EXAMPLES)
+include(build_cl2hpp)
+mark_as_advanced(
+    FG_BUILD_CUDA_EXAMPLES
+    FG_BUILD_OPENCL_EXAMPLES
+    )
 
 fg_deprecate(BUILD_EXAMPLES_CUDA FG_BUILD_CUDA_EXAMPLES)
 fg_deprecate(BUILD_EXAMPLES_OPENCL FG_BUILD_OPENCL_EXAMPLES)
-fg_deprecate(USE_SYSTEM_CL2HPP FG_USE_SYSTEM_CL2HPP)
 
 function(add_example target_name source backend)
     set(options CXX11)

--- a/examples/CMakeModules/build_cl2hpp.cmake
+++ b/examples/CMakeModules/build_cl2hpp.cmake
@@ -1,16 +1,23 @@
-if(NOT TARGET cl2hpp-ext)
-    set(FILE_URL "https://github.com/KhronosGroup/OpenCL-CLHPP/releases/download/v2.0.10/cl2.hpp")
-    set(CL_HEADER "${PROJECT_BINARY_DIR}/third_party/cl2hpp/include/CL/cl2.hpp")
-    file(DOWNLOAD ${FILE_URL} ${CL_HEADER})
-    get_filename_component(DOWNLOAD_DIR ${CL_HEADER} DIRECTORY)
-endif()
-
-message(STATUS "Found cl2.hpp header at: ${DOWNLOAD_DIR}")
-
-if (NOT TARGET OpenCL::cl2hpp)
-    add_library(OpenCL::cl2hpp IMPORTED INTERFACE GLOBAL)
-    add_dependencies(OpenCL::cl2hpp cl2hpp-ext)
-
-    set_target_properties(OpenCL::cl2hpp PROPERTIES
-        INTERFACE_INCLUDE_DIRECTORIES "${DOWNLOAD_DIR}/..")
+set(cl2hpp_header
+    "${PROJECT_BINARY_DIR}/third_party/cl2hpp/include/CL/cl2.hpp")
+if (OpenCL_FOUND)
+    if (NOT EXISTS ${cl2hpp_header})
+        set(file_url
+            "https://github.com/KhronosGroup/OpenCL-CLHPP/releases/download/v2.0.10/cl2.hpp")
+        file(DOWNLOAD ${file_url} ${cl2hpp_header}
+            EXPECTED_HASH MD5=c38d1b78cd98cc809fa2a49dbd1734a5
+            SHOW_PROGRESS STATUS download_result)
+        list(GET download_result 0 download_code)
+        if (NOT ${download_code} EQUAL 0)
+            file(REMOVE ${cl2hpp_header}) #empty file have to be removed
+            message(FATAL_ERROR "Failed to download cl2hpp header")
+        endif ()
+    endif ()
+    get_filename_component(download_dir ${cl2hpp_header} DIRECTORY)
+    message(STATUS "Found cl2.hpp header at: ${download_dir}")
+    if (NOT TARGET OpenCL::cl2hpp)
+        add_library(OpenCL::cl2hpp IMPORTED INTERFACE GLOBAL)
+        set_target_properties(OpenCL::cl2hpp PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${download_dir}/..")
+    endif ()
 endif ()


### PR DESCRIPTION
Also removed the cmake option to use system cl2.hpp header
in favor of using internally downloaded header.
