### PR TITLE
Internal API to turn off axes rendering in 2d charts

### DIFF
--- a/src/backend/common/chart.hpp
+++ b/src/backend/common/chart.hpp
@@ -53,6 +53,10 @@ class Chart {
             return mChart;
         }
 
+        void setAxesVisibility(const bool isVisible=true) {
+            mChart->setAxesVisibility(isVisible);
+        }
+
         inline void setAxesTitles(const char* pX,
                                   const char* pY,
                                   const char* pZ) {

--- a/src/backend/opengl/chart_impl.hpp
+++ b/src/backend/opengl/chart_impl.hpp
@@ -41,6 +41,7 @@ class AbstractChart : public AbstractRenderable {
         float mTopMargin;
         float mBottomMargin;
         /* chart axes ranges and titles */
+        bool  mRenderAxes;
         std::string  mXLabelFormat;
         float mXMax;
         float mXMin;
@@ -122,6 +123,8 @@ class AbstractChart : public AbstractRenderable {
         AbstractChart(const float pLeftMargin, const float pRightMargin,
                       const float pTopMargin, const float pBottomMargin);
         virtual ~AbstractChart();
+
+        void setAxesVisibility(const bool isVisible=true);
 
         void setAxesTitles(const char* pXTitle,
                            const char* pYTitle,


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, documentation update, new examples etc.)**
Internal change to disable 2d Chart axes rendering.

**What is the current behavior? (You can also link to an open issue here)**
No option to turn off 2d chart axes rendering.

**What is the new behavior (if this is a feature change)?**
Added new API (`Chart::setAxesVisibility`) at `src/backend/common` level.

**Does this PR ensure that key events handling across different window toolkits is identical if it
has changes related to window toolkits?**
NO

**Does this PR introduce a breaking change?**
No.
