### PR TITLE
Fix and Improve trackball interactivity

### DIFF
--- a/src/backend/common/defines.hpp
+++ b/src/backend/common/defines.hpp
@@ -20,11 +20,16 @@ namespace common {
 using CellIndex     = std::tuple<int, int, int>;
 using MatrixHashMap = std::unordered_map<CellIndex, glm::mat4>;
 
-constexpr float PI        = 3.14159f;
-constexpr float BLACK[]   = {0.0f, 0.0f, 0.0f, 1.0f};
-constexpr float GRAY[]    = {0.75f, 0.75f, 0.75f, 1.0f};
-constexpr float WHITE[]   = {1.0f, 1.0f, 1.0f, 1.0f};
-constexpr float AF_BLUE[] = {0.0588f, 0.1137f, 0.2745f, 1.0f};
+constexpr int ARCBALL_CIRCLE_POINTS = 100;
+constexpr float MOVE_SPEED          = 0.005f;
+constexpr float ZOOM_SPEED          = 0.0075f;
+constexpr float EPSILON             = 1.0e-6f;
+constexpr float ARC_BALL_RADIUS     = 0.75f;
+constexpr double PI                 = 3.14159265358979323846;
+constexpr float BLACK[]             = {0.0f, 0.0f, 0.0f, 1.0f};
+constexpr float GRAY[]              = {0.75f, 0.75f, 0.75f, 1.0f};
+constexpr float WHITE[]             = {1.0f, 1.0f, 1.0f, 1.0f};
+constexpr float AF_BLUE[]           = {0.0588f, 0.1137f, 0.2745f, 1.0f};
 static const glm::mat4 IDENTITY(1.0f);
 
 #if defined(OS_WIN)

--- a/src/backend/common/util.hpp
+++ b/src/backend/common/util.hpp
@@ -16,6 +16,7 @@
 
 #include <iostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace forge {
@@ -54,9 +55,19 @@ std::string toString(const float pVal, const std::string pFormat);
 /* Print glm::mat4 to std::cout stream */
 std::ostream& operator<<(std::ostream&, const glm::mat4&);
 
-/* get the point of the surface of track ball */
-glm::vec3 trackballPoint(const float pX, const float pY, const float pWidth,
-                         const float pHeight);
+/* Calculate rotation axis and amount of rotation of Arc Ball
+ *
+ * This computation requires previous and current mouse cursor positions
+ * which are the input parameters to this function call
+ *
+ * @lastPos previous mouse position
+ * @currPos current mouse position
+ *
+ * @return Rotation axis vector and the angle of rotation
+ * */
+std::pair<glm::vec3, float> calcRotationFromArcBall(const glm::vec2& lastPos,
+                                                    const glm::vec2& currPos,
+                                                    const glm::vec4& viewport);
 
 }  // namespace common
 }  // namespace forge

--- a/src/backend/glsl_shaders/plot3_fs.glsl
+++ b/src/backend/glsl_shaders/plot3_fs.glsl
@@ -3,31 +3,33 @@
 uniform vec2 minmaxs[3];
 uniform bool isPVCOn;
 uniform bool isPVAOn;
+uniform bool isAssistDraw;
+uniform vec4 lineColor;
 
 in vec4 hpoint;
 in vec4 pervcol;
 
 out vec4 outColor;
 
-vec3 hsv2rgb(vec3 c)
-{
-   vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
-   vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
-   return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+vec3 hsv2rgb(vec3 c) {
+    vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+    vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+    return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
 }
 
-void main(void)
-{
-   bool nin_bounds = (hpoint.x > minmaxs[0].y || hpoint.x < minmaxs[0].x
-                   || hpoint.y > minmaxs[1].y || hpoint.y < minmaxs[1].x
-                   || hpoint.z < minmaxs[2].x);
+void main(void) {
+    bool nin_bounds = (hpoint.x > minmaxs[0].y || hpoint.x < minmaxs[0].x ||
+                       hpoint.y > minmaxs[1].y || hpoint.y < minmaxs[1].x ||
+                       hpoint.z < minmaxs[2].x);
 
-   float height = (minmaxs[2].y- hpoint.z)/(minmaxs[2].y-minmaxs[2].x);
+    float height = (minmaxs[2].y - hpoint.z) / (minmaxs[2].y - minmaxs[2].x);
 
-   float a  = isPVAOn ? pervcol.w : 1.0;
+    float a = isPVAOn ? pervcol.w : 1.0;
 
-   if(nin_bounds)
-       discard;
-   else
-       outColor = isPVCOn ? vec4(pervcol.xyz, a) : vec4(hsv2rgb(vec3(height, 1, 1)),a);
+    if (nin_bounds)
+        discard;
+    else
+        outColor = isPVCOn        ? vec4(pervcol.xyz, a)
+                   : isAssistDraw ? lineColor
+                                  : vec4(hsv2rgb(vec3(height, 1, 1)), a);
 }

--- a/src/backend/opengl/abstract_renderable.hpp
+++ b/src/backend/opengl/abstract_renderable.hpp
@@ -36,6 +36,7 @@ class AbstractRenderable {
     std::string mLegend;
     bool mIsPVCOn;
     bool mIsPVAOn;
+    bool mIsInternalObject;
 
     AbstractRenderable()
         : mVBO(0)
@@ -45,7 +46,8 @@ class AbstractRenderable {
         , mCBOSize(0)
         , mABOSize(0)
         , mIsPVCOn(0)
-        , mIsPVAOn(0) {
+        , mIsPVAOn(0)
+        , mIsInternalObject(false) {
         mColor[0] = 0;
         mColor[1] = 0;
         mColor[2] = 0;
@@ -147,6 +149,16 @@ class AbstractRenderable {
     virtual void render(const int pWindowId, const int pX, const int pY,
                         const int pVPW, const int pVPH, const glm::mat4& pView,
                         const glm::mat4& pOrient) = 0;
+
+    /*
+     * Mark the renderable is for internal use for assistive help
+     */
+    inline void markAsInternalObject() { mIsInternalObject = true; }
+
+    /*
+     * Only rotatble renderables need to show 3d dimenionsional helper objects
+     */
+    virtual bool isRotatable() const = 0;
 };
 
 }  // namespace opengl

--- a/src/backend/opengl/chart_impl.hpp
+++ b/src/backend/opengl/chart_impl.hpp
@@ -170,6 +170,8 @@ class chart2d_impl : public AbstractChart {
     void render(const int pWindowId, const int pX, const int pY, const int pVPW,
                 const int pVPH, const glm::mat4& pView,
                 const glm::mat4& pOrient);
+
+    bool isRotatable() const { return false; }
 };
 
 class chart3d_impl : public AbstractChart {
@@ -191,6 +193,8 @@ class chart3d_impl : public AbstractChart {
     void render(const int pWindowId, const int pX, const int pY, const int pVPW,
                 const int pVPH, const glm::mat4& pView,
                 const glm::mat4& pOrient);
+
+    bool isRotatable() const { return true; }
 };
 
 }  // namespace opengl

--- a/src/backend/opengl/glfw/window.hpp
+++ b/src/backend/opengl/glfw/window.hpp
@@ -29,11 +29,13 @@ void destroyWindowToolkit();
 class Widget {
    private:
     GLFWwindow* mWindow;
+    GLFWcursor* mRotationCursor;
+    GLFWcursor* mZoomCursor;
     bool mClose;
-    float mLastXPos;
-    float mLastYPos;
+    glm::vec2 mLastPos;
     int mButton;
-    glm::vec3 mLastPos;
+    int mButtonAction;
+    bool mRotationFlag;
 
     forge::common::MatrixHashMap mViewMatrices;
     forge::common::MatrixHashMap mOrientMatrices;
@@ -104,6 +106,8 @@ class Widget {
         const forge::common::CellIndex& pIndex);
     void resetViewMatrices();
     void resetOrientationMatrices();
+
+    inline bool isBeingRotated() const { return mRotationFlag; }
 };
 
 }  // namespace wtk

--- a/src/backend/opengl/histogram_impl.cpp
+++ b/src/backend/opengl/histogram_impl.cpp
@@ -160,5 +160,7 @@ void histogram_impl::render(const int pWindowId, const int pX, const int pY,
     CheckGL("End histogram_impl::render");
 }
 
+bool histogram_impl::isRotatable() const { return false; }
+
 }  // namespace opengl
 }  // namespace forge

--- a/src/backend/opengl/histogram_impl.hpp
+++ b/src/backend/opengl/histogram_impl.hpp
@@ -54,6 +54,8 @@ class histogram_impl : public AbstractRenderable {
     void render(const int pWindowId, const int pX, const int pY, const int pVPW,
                 const int pVPH, const glm::mat4 &pView,
                 const glm::mat4 &pOrient);
+
+    bool isRotatable() const;
 };
 
 }  // namespace opengl

--- a/src/backend/opengl/image_impl.cpp
+++ b/src/backend/opengl/image_impl.cpp
@@ -190,5 +190,7 @@ void image_impl::render(const int pWindowId, const int pX, const int pY,
     CheckGL("End image_impl::render");
 }
 
+bool image_impl::isRotatable() const { return false; }
+
 }  // namespace opengl
 }  // namespace forge

--- a/src/backend/opengl/image_impl.hpp
+++ b/src/backend/opengl/image_impl.hpp
@@ -67,6 +67,8 @@ class image_impl : public AbstractRenderable {
     void render(const int pWindowId, const int pX, const int pY, const int pVPW,
                 const int pVPH, const glm::mat4 &pView,
                 const glm::mat4 &pOrient);
+
+    bool isRotatable() const;
 };
 
 }  // namespace opengl

--- a/src/backend/opengl/plot_impl.hpp
+++ b/src/backend/opengl/plot_impl.hpp
@@ -43,6 +43,8 @@ class plot_impl : public AbstractRenderable {
     uint32_t mPlotPointIndex;
     uint32_t mPlotColorIndex;
     uint32_t mPlotAlphaIndex;
+    uint32_t mPlotAssistDrawFlagIndex;
+    uint32_t mPlotLineColorIndex;
 
     uint32_t mMarkerPVCOnIndex;
     uint32_t mMarkerPVAOnIndex;
@@ -72,7 +74,8 @@ class plot_impl : public AbstractRenderable {
    public:
     plot_impl(const uint32_t pNumPoints, const forge::dtype pDataType,
               const forge::PlotType pPlotType,
-              const forge::MarkerType pMarkerType, const int pDimension = 3);
+              const forge::MarkerType pMarkerType, const int pDimension = 3,
+              const bool pIsInternalObject = false);
     ~plot_impl();
 
     void setMarkerSize(const float pMarkerSize);
@@ -83,6 +86,8 @@ class plot_impl : public AbstractRenderable {
     virtual void render(const int pWindowId, const int pX, const int pY,
                         const int pVPW, const int pVPH, const glm::mat4& pView,
                         const glm::mat4& pOrient);
+
+    virtual bool isRotatable() const;
 };
 
 class plot2d_impl : public plot_impl {
@@ -98,6 +103,8 @@ class plot2d_impl : public plot_impl {
                 const forge::PlotType pPlotType,
                 const forge::MarkerType pMarkerType)
         : plot_impl(pNumPoints, pDataType, pPlotType, pMarkerType, 2) {}
+
+    bool isRotatable() const;
 };
 
 }  // namespace opengl

--- a/src/backend/opengl/sdl/window.hpp
+++ b/src/backend/opengl/sdl/window.hpp
@@ -29,13 +29,14 @@ class Widget {
    private:
     SDL_Window* mWindow;
     SDL_GLContext mContext;
+    SDL_Cursor* mDefaultCursor;
+    SDL_Cursor* mRotationCursor;
+    SDL_Cursor* mZoomCursor;
+    SDL_Cursor* mMoveCursor;
     bool mClose;
     uint32_t mWindowId;
-    float mLastXPos;
-    float mLastYPos;
-    int mButton;
-    SDL_Keycode mMod;
-    glm::vec3 mLastPos;
+    glm::vec2 mLastPos;
+    bool mRotationFlag;
 
     forge::common::MatrixHashMap mViewMatrices;
     forge::common::MatrixHashMap mOrientMatrices;
@@ -102,6 +103,8 @@ class Widget {
         const forge::common::CellIndex& pIndex);
     void resetViewMatrices();
     void resetOrientationMatrices();
+
+    inline bool isBeingRotated() const { return mRotationFlag; }
 };
 
 }  // namespace wtk

--- a/src/backend/opengl/surface_impl.cpp
+++ b/src/backend/opengl/surface_impl.cpp
@@ -121,6 +121,8 @@ void surface_impl::renderGraph(const int pWindowId,
     glUniform2fv(mSurfRangeIndex, 3, mRange);
     glUniform1i(mSurfPVCIndex, mIsPVCOn);
     glUniform1i(mSurfPVAIndex, mIsPVAOn);
+    glUniform1i(mSurfAssistDrawFlagIndex, false);
+    glUniform4fv(mSurfUniformColorIndex, 1, mColor);
 
     bindResources(pWindowId);
     glDrawElements(GL_TRIANGLE_STRIP, GLsizei(mIBOSize), GL_UNSIGNED_INT,
@@ -174,7 +176,9 @@ surface_impl::surface_impl(unsigned pNumXPoints, unsigned pNumYPoints,
     , mSurfColorIndex(-1)
     , mSurfAlphaIndex(-1)
     , mSurfPVCIndex(-1)
-    , mSurfPVAIndex(-1) {
+    , mSurfPVAIndex(-1)
+    , mSurfUniformColorIndex(-1)
+    , mSurfAssistDrawFlagIndex(-1) {
     CheckGL("Begin surface_impl::surface_impl");
     setColor(0.9f, 0.5f, 0.6f, 1.0f);
 
@@ -187,13 +191,15 @@ surface_impl::surface_impl(unsigned pNumXPoints, unsigned pNumYPoints,
     mMarkerColorIndex = mMarkerProgram.getAttributeLocation("color");
     mMarkerAlphaIndex = mMarkerProgram.getAttributeLocation("alpha");
 
-    mSurfMatIndex   = mSurfProgram.getUniformLocation("transform");
-    mSurfRangeIndex = mSurfProgram.getUniformLocation("minmaxs");
-    mSurfPVCIndex   = mSurfProgram.getUniformLocation("isPVCOn");
-    mSurfPVAIndex   = mSurfProgram.getUniformLocation("isPVAOn");
-    mSurfPointIndex = mSurfProgram.getAttributeLocation("point");
-    mSurfColorIndex = mSurfProgram.getAttributeLocation("color");
-    mSurfAlphaIndex = mSurfProgram.getAttributeLocation("alpha");
+    mSurfMatIndex            = mSurfProgram.getUniformLocation("transform");
+    mSurfRangeIndex          = mSurfProgram.getUniformLocation("minmaxs");
+    mSurfPVCIndex            = mSurfProgram.getUniformLocation("isPVCOn");
+    mSurfPVAIndex            = mSurfProgram.getUniformLocation("isPVAOn");
+    mSurfPointIndex          = mSurfProgram.getAttributeLocation("point");
+    mSurfColorIndex          = mSurfProgram.getAttributeLocation("color");
+    mSurfAlphaIndex          = mSurfProgram.getAttributeLocation("alpha");
+    mSurfUniformColorIndex   = mSurfProgram.getUniformLocation("lineColor");
+    mSurfAssistDrawFlagIndex = mSurfProgram.getUniformLocation("isAssistDraw");
 
     unsigned totalPoints = mNumXPoints * mNumYPoints;
 

--- a/src/backend/opengl/surface_impl.hpp
+++ b/src/backend/opengl/surface_impl.hpp
@@ -47,6 +47,8 @@ class surface_impl : public AbstractRenderable {
     uint32_t mSurfAlphaIndex;
     uint32_t mSurfPVCIndex;
     uint32_t mSurfPVAIndex;
+    uint32_t mSurfUniformColorIndex;
+    uint32_t mSurfAssistDrawFlagIndex;
 
     std::map<int, uint32_t> mVAOMap;
 
@@ -75,6 +77,8 @@ class surface_impl : public AbstractRenderable {
     inline void usePerVertexAlphas(const bool pFlag = true) {
         mIsPVAOn = pFlag;
     }
+
+    bool isRotatable() const { return true; }
 };
 
 class scatter3_impl : public surface_impl {

--- a/src/backend/opengl/vector_field_impl.cpp
+++ b/src/backend/opengl/vector_field_impl.cpp
@@ -216,6 +216,8 @@ void vector_field_impl::render(const int pWindowId, const int pX, const int pY,
     CheckGL("End vector_field_impl::render");
 }
 
+bool vector_field_impl::isRotatable() const { return true; }
+
 glm::mat4 vector_field2d_impl::computeModelMatrix(
     const glm::mat4& /*pOrient*/) {
     float xRange = mRange[1] - mRange[0];

--- a/src/backend/opengl/vector_field_impl.hpp
+++ b/src/backend/opengl/vector_field_impl.hpp
@@ -64,6 +64,8 @@ class vector_field_impl : public AbstractRenderable {
     virtual void render(const int pWindowId, const int pX, const int pY,
                         const int pVPW, const int pVPH, const glm::mat4& pView,
                         const glm::mat4& pOrient);
+
+    virtual bool isRotatable() const;
 };
 
 class vector_field2d_impl : public vector_field_impl {
@@ -73,6 +75,8 @@ class vector_field2d_impl : public vector_field_impl {
    public:
     vector_field2d_impl(const uint32_t pNumPoints, const forge::dtype pDataType)
         : vector_field_impl(pNumPoints, pDataType, 2) {}
+
+    bool isRotatable() const { return false; }
 };
 
 }  // namespace opengl

--- a/src/backend/opengl/window_impl.hpp
+++ b/src/backend/opengl/window_impl.hpp
@@ -16,6 +16,7 @@
 #include <common/defines.hpp>
 #include <font_impl.hpp>
 #include <image_impl.hpp>
+#include <plot_impl.hpp>
 
 #include <memory>
 
@@ -31,9 +32,13 @@ class window_impl {
 
     std::shared_ptr<font_impl> mFont;
     std::shared_ptr<colormap_impl> mCMap;
+    std::shared_ptr<plot_impl> mArcBallLoop0;
+    std::shared_ptr<plot_impl> mArcBallLoop1;
 
     uint32_t mColorMapUBO;
     uint32_t mUBOSize;
+
+    void prepArcBallObjects();
 
    public:
     window_impl(int pWidth, int pHeight, const char* pTitle,


### PR DESCRIPTION
- A very basic wire-ball of two loops is shown when rotation is being done to better hint the user of the direction of rotation.
- Fixed bug in trackball computation that was incorrectly using angle
  in degrees instead of radians
- Add custom Cursors for zoom and rotation modes to visually aid the
  user
  - Hand cursor appears when rotation is activated(Mouse Right button
    drag)
  - Arrow with top and bottom heads is activated when zoom in/out mode
    is active(Ctrl + Left Right button) to hint the required cursor
    movement for desired zoom in or zoom out

SDL window toolkit additionally has custom move cursor.

**Change(s)**
Trackball rotation has a bug in computing the angle.

**Current Behavior**
Incorrectly uses degrees unit instead of radians

**New Behavior**
Fixed angle units and improved interactivity hints

**Breaking Change(s)**
None