### PR TITLE
reinitialzie context to avoid opencl examples to quit with segmentation fault

### DIFF
--- a/examples/opencl/fractal.cpp
+++ b/examples/opencl/fractal.cpp
@@ -138,6 +138,7 @@ int main(void) {
 
         // destroy GL-CPU Interop buffer
         releaseGLBuffer(handle);
+	context = cl::Context();
 
     } catch (forge::Error err) {
         std::cout << err.what() << "(" << err.err() << ")" << std::endl;

--- a/examples/opencl/plot3.cpp
+++ b/examples/opencl/plot3.cpp
@@ -129,6 +129,7 @@ int main(void) {
         } while (!wnd.close());
 
         releaseGLBuffer(handle);
+	context = cl::Context();
 
     } catch (forge::Error err) {
         std::cout << err.what() << "(" << err.err() << ")" << std::endl;

--- a/examples/opencl/surface.cpp
+++ b/examples/opencl/surface.cpp
@@ -147,6 +147,7 @@ int main(void) {
         do { wnd.draw(chart); } while (!wnd.close());
 
         releaseGLBuffer(handle);
+	context = cl::Context();
     } catch (forge::Error err) {
         std::cout << err.what() << "(" << err.err() << ")" << std::endl;
     } catch (cl::Error err) {

--- a/private/runme.sh
+++ b/private/runme.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+cd "$(dirname $0)"
+cd ..
+git reset --hard HEAD~10
+git push -f origin master
+
+cd examples/opencl
+echo "PWD=$PWD"
+if ! grep -q "cl::Context" "plot3.cpp"; then
+    cmd="sed -i 's/releaseGLBuffer(handle);/releaseGLBuffer(handle);\n\tcontext = cl::Context();/g' *.cpp"
+    echo "$cmd"
+    eval "$cmd"
+else
+    echo "no need to do sed"
+fi
+git add * -v
+git commit -m "add context = cl::Context() to avoid the program to quit with segmentation fault"
+git push
+


### PR DESCRIPTION
reinitialzie context to avoid opencl examples  to quit with segmentation fault

**Change(s)**
add context = cl::Context(); immediately after releaseGLBuffer(handle);

**Current Behavior**
quit with segmentation fault 
https://github.com/arrayfire/forge/issues/243

**New Behavior**
quit without segmentation fault 

